### PR TITLE
# CLI did not work at all from the command line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,5 @@ jobs:
       - name: Build solution
         run: dotnet build ImageResizer.slnx --configuration Release --no-restore
 
-      # No test projects exist in this repo -- build success is the only CI signal.
-      - name: No tests to run
-        run: echo "No test project -- build-only CI."
+      - name: Run tests
+        run: dotnet test ImageResizer.slnx --configuration Release --no-build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ per-repo distillation.
 The flagship **pixel-art scaling collection**: dozens of upscalers (HQ, XBR,
 Eagle, Scale…), resamplers, downsamplers, filters, quantizers and ditherers.
 Solution `ImageResizer.slnx`: GUI app (`ImageResizer`), the algorithm library
-(`ImageResizerLibrary`), and `PixelArtScalingPlugin`. Filter names follow
+(`ImageResizerLibrary`), `PixelArtScalingPlugin`, and the test projects under
+`Tests/`. Filter names follow
 the category-prefix scheme documented in the README — keep code, GUI
 dropdown and README in sync.
 
@@ -26,8 +27,8 @@ dropdown and README in sync.
 
 ## The loop (always, in this order)
 
-1. **Before committing**: `dotnet build ImageResizer.slnx -c Release` and the
-   tests until green; scaling changes get an eyeball comparison against the
+1. **Before committing**: `dotnet build ImageResizer.slnx -c Release` and
+   `dotnet test ImageResizer.slnx -c Release` until green; scaling changes get an eyeball comparison against the
    reference output of the affected algorithm — visual regressions don't
    show in unit tests.
 2. **Commit** (rules above) and **push**.

--- a/ImageResizer.slnx
+++ b/ImageResizer.slnx
@@ -7,6 +7,9 @@
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
   </Folder>
+  <Folder Name="/Tests/">
+    <Project Path="Tests/ImageResizer.Tests/ImageResizer.Tests.csproj" />
+  </Folder>
   <Project Path="ImageResizer/ImageResizer.csproj" />
   <Project Path="ImageResizerLibrary/ImageResizerLibrary.csproj" />
   <Project Path="PixelArtScalingPlugin/PixelArtScaling.csproj" />

--- a/ImageResizer/Classes/CLI.cs
+++ b/ImageResizer/Classes/CLI.cs
@@ -40,12 +40,23 @@ namespace Classes {
   internal static class CLI {
 
     /// <summary>
+    /// The arguments that ask for the help text rather than for work.
+    /// </summary>
+    private static readonly string[] _HELP_ARGUMENTS = { "/?", "-?", "--?", "/h", "-h", "/help", "--help" };
+
+    /// <summary>
     /// Parses the command line arguments.
     /// </summary>
     /// <param name="arguments">The arguments.</param>
     public static CLIExitCode ParseCommandLineArguments(string[] arguments) {
       if (arguments == null || arguments.Length < 1)
         return CLIExitCode.OK;
+
+      // only the leading argument, so a file that happens to be named like a switch stays a file
+      if (_HELP_ARGUMENTS.Contains(arguments[0], StringComparer.OrdinalIgnoreCase)) {
+        _ShowHelp();
+        return CLIExitCode.OK;
+      }
 
       var engine = new ScriptEngine();
       var line = string.Join(" ", arguments.Select(a => string.Format(@"""{0}""", a)));
@@ -57,6 +68,7 @@ namespace Classes {
       try {
         ScriptSerializer.LoadFromString(engine, line);
       } catch (ScriptSerializerException e) {
+        _ShowError(e);
         _ShowHelp();
         return e.ErrorType;
       }
@@ -158,6 +170,56 @@ namespace Classes {
           return pair.Key;
 
       return ReflectionUtils.GetDescriptionForClass(manipulator.GetType());
+    }
+
+    /// <summary>
+    /// Explains why a script could not be parsed. Without this the CLI answered every malformed
+    /// command line with nothing but the help text, leaving the user to guess which token it
+    /// choked on.
+    /// </summary>
+    /// <param name="exception">The parse failure.</param>
+    private static void _ShowError(ScriptSerializerException exception) {
+      var origin = exception.Filename == null
+        ? string.Empty
+        : string.Format(" in {0}, line {1}", exception.Filename, exception.LineNumber)
+        ;
+
+      Console.WriteLine("ERROR{0}: {1}", origin, _GetErrorText(exception.ErrorType));
+      Console.WriteLine();
+    }
+
+    /// <summary>
+    /// Gets a human-readable explanation for an exit code.
+    /// </summary>
+    /// <param name="exitCode">The exit code.</param>
+    /// <returns>The explanation.</returns>
+    private static string _GetErrorText(CLIExitCode exitCode) {
+      switch (exitCode) {
+        case CLIExitCode.UnknownParameter:
+          return "Unknown command or filter parameter - see the list of supported filter methods below.";
+        case CLIExitCode.TooLessArguments:
+          return "A command is missing arguments.";
+        case CLIExitCode.FilenameMustNotBeNull:
+          return "A file name is missing.";
+        case CLIExitCode.InvalidTargetDimensions:
+          return "Invalid target dimensions - expected auto, w<x>, h<y>, <x>x<y> or <p>%.";
+        case CLIExitCode.CouldNotParseDimensionsAsWord:
+          return "Target dimensions out of range - width, height and percentage must be 0-65535.";
+        case CLIExitCode.UnknownFilter:
+          return "Unknown filter method - see the list of supported filter methods below.";
+        case CLIExitCode.AmbiguousFilter:
+          return "Ambiguous filter method - more than one category provides it, so prefix it with the category shown in the list below.";
+        case CLIExitCode.InvalidFilterDescription:
+          return "Invalid filter description - expected <method>[(<repeat>|<paramlist>)].";
+        case CLIExitCode.CouldNotParseParameterAsFloat:
+          return "A filter parameter that must be a floating point value is not one.";
+        case CLIExitCode.CouldNotParseParameterAsByte:
+          return "A filter parameter that must be a value 0-255 is not one.";
+        case CLIExitCode.InvalidOutOfBoundsMode:
+          return "Invalid out of bounds mode - expected const, half, whole, wrap or transparent.";
+        default:
+          return exitCode.ToString();
+      }
     }
 
     /// <summary>

--- a/ImageResizer/Classes/CLI.cs
+++ b/ImageResizer/Classes/CLI.cs
@@ -81,7 +81,7 @@ namespace Classes {
           Console.WriteLine("Saving to file " + saveCommand.FileName);
           break;
         case ResizeCommand resizeCommand:
-          Console.WriteLine("Applying filter     : {0}", SupportedManipulators.MANIPULATORS.First(k => k.Value == resizeCommand.Manipulator).Key);
+          Console.WriteLine("Applying filter     : {0}", _GetManipulatorName(resizeCommand.Manipulator));
           Console.WriteLine("  Target percentage : {0}", resizeCommand.Percentage == 0 ? "auto" : resizeCommand.Percentage + "%");
           Console.WriteLine("  Target width      : {0}", resizeCommand.Width == 0 ? "auto" : resizeCommand.Width + "pixels");
           Console.WriteLine("  Target height     : {0}", resizeCommand.Height == 0 ? "auto" : resizeCommand.Height + "pixels");
@@ -98,24 +98,66 @@ namespace Classes {
     private static void _PostAction(ScriptEngine engine, IScriptAction command) {
       switch (command) {
         case LoadFileCommand loadCommand:
-          Console.WriteLine("  File   : {0} Bytes", new FileInfo(loadCommand.FileName).Length);
-          Console.WriteLine("  Width  : {0} Pixel", engine.SourceImage.Width);
-          Console.WriteLine("  Height : {0} Pixel", engine.SourceImage.Height);
-          Console.WriteLine("  Size   : {0:0.00} MegaPixel", engine.SourceImage.Width * engine.SourceImage.Height / 1000000.0);
-          Console.WriteLine("  Type   : {0}", ImageCodecInfo.GetImageDecoders().First(d => d.FormatID == engine.GdiSource.RawFormat.Guid).FormatDescription);
-          Console.WriteLine("  Format : {0}", engine.GdiSource.PixelFormat);
+          _PrintImageFileDetails(loadCommand.FileName);
           return;
-        case SaveFileCommand saveCommand: {
-          var reloadedImage = Image.FromFile(saveCommand.FileName);
-          Console.WriteLine("  File   : {0} Bytes", new FileInfo(saveCommand.FileName).Length);
-          Console.WriteLine("  Width  : {0} Pixel", reloadedImage.Width);
-          Console.WriteLine("  Height : {0} Pixel", reloadedImage.Height);
-          Console.WriteLine("  Size   : {0:0.00} MegaPixel", reloadedImage.Width * reloadedImage.Height / 1000000.0);
-          Console.WriteLine("  Type   : {0}", ImageCodecInfo.GetImageDecoders().First(d => d.FormatID == reloadedImage.RawFormat.Guid).FormatDescription);
-          Console.WriteLine("  Format : {0}", reloadedImage.PixelFormat);
+        case SaveFileCommand saveCommand:
+          _PrintImageFileDetails(saveCommand.FileName);
           break;
-        }
       }
+    }
+
+    /// <summary>
+    /// Prints size and format details of an image file.
+    /// <para>
+    /// The details are read back from the file rather than from the engine's bitmaps on purpose:
+    /// the engine holds in-memory copies whose <see cref="Image.RawFormat"/> is
+    /// <see cref="ImageFormat.MemoryBmp"/>, and GDI+ registers no decoder for that - looking one
+    /// up used to throw and take the whole run down with it.
+    /// </para>
+    /// <para>
+    /// This is diagnostic output; it must never be able to abort a pipeline, hence the blanket
+    /// catch.
+    /// </para>
+    /// </summary>
+    /// <param name="fileName">The image file to describe.</param>
+    private static void _PrintImageFileDetails(string fileName) {
+      try {
+        Console.WriteLine("  File   : {0} Bytes", new FileInfo(fileName).Length);
+
+        // no validation and no embedded colour management - we only want the header
+        using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
+        using (var image = Image.FromStream(stream, false, false)) {
+          Console.WriteLine("  Width  : {0} Pixel", image.Width);
+          Console.WriteLine("  Height : {0} Pixel", image.Height);
+          Console.WriteLine("  Size   : {0:0.00} MegaPixel", image.Width * image.Height / 1000000.0);
+          Console.WriteLine("  Type   : {0}", _GetFormatDescription(image.RawFormat));
+          Console.WriteLine("  Format : {0}", image.PixelFormat);
+        }
+      } catch (Exception e) {
+        Console.WriteLine("  (details unavailable: {0})", e.Message);
+      }
+    }
+
+    /// <summary>
+    /// Gets the human-readable description of an image format, e.g. <c>"PNG"</c>.
+    /// </summary>
+    /// <param name="format">The format.</param>
+    /// <returns>The decoder's description, or the format's own name when no decoder knows it.</returns>
+    private static string _GetFormatDescription(ImageFormat format)
+      => ImageCodecInfo.GetImageDecoders().FirstOrDefault(d => d.FormatID == format.Guid)?.FormatDescription ?? format.ToString()
+    ;
+
+    /// <summary>
+    /// Gets the registered name of a manipulator.
+    /// </summary>
+    /// <param name="manipulator">The manipulator.</param>
+    /// <returns>The name it is registered under, or its description when it is not registered.</returns>
+    private static string _GetManipulatorName(IImageManipulator manipulator) {
+      foreach (var pair in SupportedManipulators.MANIPULATORS)
+        if (ReferenceEquals(pair.Value, manipulator))
+          return pair.Key;
+
+      return ReflectionUtils.GetDescriptionForClass(manipulator.GetType());
     }
 
     /// <summary>

--- a/ImageResizer/Classes/CLIExitCode.cs
+++ b/ImageResizer/Classes/CLIExitCode.cs
@@ -38,6 +38,7 @@ namespace Classes {
     CouldNotParseParameterAsFloat=13,
     CouldNotParseParameterAsByte=14,
     InvalidOutOfBoundsMode=15,
+    AmbiguousFilter=18,
 
     RuntimeError=16,
   }

--- a/ImageResizer/Classes/ScriptSerializer.cs
+++ b/ImageResizer/Classes/ScriptSerializer.cs
@@ -65,6 +65,12 @@ namespace Classes {
     internal const string HBOUNDS_PARAMETER_NAME = "hbounds";
     internal const string VBOUNDS_PARAMETER_NAME = "vbounds";
 
+    /// <summary>
+    /// Separates the category from the filter name in a manipulator key, as in
+    /// <c>"Upscaler: HQ 2x"</c>.
+    /// </summary>
+    internal const string CATEGORY_SEPARATOR = ": ";
+
     internal const string LOAD_COMMAND_NAME = "/load";
     internal const string SCRIPT_COMMAND_NAME = "/script";
     internal const string SAVE_COMMAND_NAME = "/save";
@@ -346,17 +352,58 @@ namespace Classes {
       }
 
       // find the given manipulator
-      var manipulator = SupportedManipulators.MANIPULATORS
-        .Where(resizer => string.Compare(resizer.Key, filterName, true) == 0)
-        .Select(kvp => kvp.Value)
-        .FirstOrDefault()
-      ;
+      var manipulator = FindManipulator(SupportedManipulators.MANIPULATORS, filterName, out var isAmbiguous);
+      if (isAmbiguous)
+        return CLIExitCode.AmbiguousFilter;
 
       if (manipulator == null)
         return CLIExitCode.UnknownFilter;
 
       engine.AddWithoutExecution(new ResizeCommand(true, manipulator, targetWidth, targetHeight, targetPercent, useAspect, hbounds, vbounds, repeat, useThresholds, useCenteredGrid, radius));
       return CLIExitCode.OK;
+    }
+
+    /// <summary>
+    /// Resolves a filter name to the manipulator it names.
+    /// <para>
+    /// Manipulator keys carry the category they were registered under, e.g.
+    /// <c>"Upscaler: HQ 2x"</c>. Command lines and script files written before that scheme
+    /// existed name the filter alone, e.g. <c>"HQ 2x"</c>, so the full key is tried first and the
+    /// bare name second - the latter matched against everything each key holds after its first
+    /// <see cref="CATEGORY_SEPARATOR"/>. Categories are derived when the manipulator list is
+    /// built, so they are deliberately not enumerated here.
+    /// </para>
+    /// </summary>
+    /// <param name="manipulators">The registered manipulators to search.</param>
+    /// <param name="filterName">The name to resolve; matched case-insensitively.</param>
+    /// <param name="isAmbiguous">Set when a bare name is provided by more than one category.</param>
+    /// <returns>The manipulator, or <c>null</c> when no filter matches or the name is ambiguous.</returns>
+    internal static IImageManipulator FindManipulator(KeyValuePair<string, IImageManipulator>[] manipulators, string filterName, out bool isAmbiguous) {
+      isAmbiguous = false;
+
+      foreach (var pair in manipulators)
+        if (string.Equals(pair.Key, filterName, StringComparison.OrdinalIgnoreCase))
+          return pair.Value;
+
+      IImageManipulator result = null;
+      foreach (var pair in manipulators) {
+        var index = pair.Key.IndexOf(CATEGORY_SEPARATOR, StringComparison.Ordinal);
+        if (index < 0)
+          continue;
+
+        if (!string.Equals(pair.Key.Substring(index + CATEGORY_SEPARATOR.Length), filterName, StringComparison.OrdinalIgnoreCase))
+          continue;
+
+        // two categories offering the same bare name - the user has to say which
+        if (result != null) {
+          isAmbiguous = true;
+          return null;
+        }
+
+        result = pair.Value;
+      }
+
+      return result;
     }
 
     /// <summary>

--- a/ImageResizer/Classes/ScriptSerializer.cs
+++ b/ImageResizer/Classes/ScriptSerializer.cs
@@ -38,9 +38,15 @@ namespace Classes {
     /// </summary>
     public const string DEFAULT_FILE_EXTENSION = ".irs";
     /// <summary>
-    /// Used to identify the dimensions
+    /// Used to identify the dimensions.
+    /// <para>
+    /// Note the non-capturing group around the alternation: without it <c>^</c> and <c>$</c> bind
+    /// to the first and last branch only, so anything containing a valid branch anywhere would be
+    /// accepted. The percentage branch must capture its digits, too - it used to be an empty group,
+    /// which silently turned every <c>&lt;p&gt;%</c> into <c>auto</c>.
+    /// </para>
     /// </summary>
-    private static readonly Regex _DIMENSIONS_REGEX = new Regex(@"^(auto)|(w(?<width>[0-9]+))|(h(?<height>[0-9]+))|((?<width>[0-9]+)x(?<height>[0-9]+))|((?<percent>)%)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex _DIMENSIONS_REGEX = new Regex(@"^(?:auto|w(?<width>[0-9]+)|h(?<height>[0-9]+)|(?<width>[0-9]+)x(?<height>[0-9]+)|(?<percent>[0-9]+)%)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     /// <summary>
     /// Used to identify filter name and parameters
     /// </summary>

--- a/ImageResizer/Properties/AssemblyInfo.cs
+++ b/ImageResizer/Properties/AssemblyInfo.cs
@@ -1,6 +1,10 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
+
+// The CLI and its script parser are internal; the test project needs to reach them.
+[assembly: InternalsVisibleTo("ImageResizer.Tests")]
 
 // Durch Festlegen von ComVisible auf "false" werden die Typen in dieser Assembly unsichtbar 
 // für COM-Komponenten. Wenn Sie auf einen Typ in dieser Assembly von 

--- a/ImageResizer/Resources/CLIHelpText.txt
+++ b/ImageResizer/Resources/CLIHelpText.txt
@@ -21,6 +21,7 @@ How to use :
 ============
 
 {location} [{load} <source>] [{stdin}] [{resize} <dimensions> <method>[(<repeat>|<paramlist>)]] [{save} <target>] [{script} <script>] [{stdout}]...
+{location} /?
 
 ============
 Explanation:
@@ -37,6 +38,8 @@ Explanation:
   {script}        - Processes a script file in the current chain.
     <script>     - the name of the script file - take care not to build recursive scripts !
 
+  /?             - Shows this help. Also accepted: -?, --?, /h, -h, /help, --help
+
   {resize}        - Resizes the image in the buffer and stores the result back to the buffer.
     <dimensions> - auto | w<x> | h<y> | <x>x<y> | <p>%
                    If only width or height is specified, the other dimension is auto-detected by aspect ratio
@@ -44,7 +47,9 @@ Explanation:
       <x>        - the final width in pixels for the target
       <y>        - the final height in pixels for the target
       <p>        - the percentage to resize eg 400% for 4-times resizing
-    <method>     - the method to use
+    <method>     - the method to use, as listed under "Supported filter methods" below
+                   Methods are listed as "<category>: <name>". The category may be left out as
+                   long as no other category offers a method of the same name.
     <repeat>     - the number of repetitions using this method
     <paramlist>  - a list of parameters to apply, separated using ',' and assigned using '='; eg. radius=4, centeredGrid=0
       {radius}     - a floating point value setting the radius of the filter
@@ -58,22 +63,25 @@ Explanation:
 Examples:
 =========
 
-{location} {load} input.bmp {resize} 72x92 "Bicubic(vbounds=wrap)" {save} output.png
-{location} {load} input.bmp {resize} w72 "Bicubic" {save} output.png
-{location} {load} input.bmp {resize} h92 "Bicubic(vbounds=whole,hbounds=whole)" {save} output.png
-{location} {load} input.bmp {resize} 325% "Bicubic" {save} output.png
-{location} {load} input.bmp {resize} auto "LQ 2x Smart" {save} output.png
+{location} {load} input.bmp {resize} 72x92 "Resampler: Bicubic(vbounds=wrap)" {save} output.png
+{location} {load} input.bmp {resize} w72 "Resampler: Bicubic" {save} output.png
+{location} {load} input.bmp {resize} h92 "Resampler: Bicubic(vbounds=whole,hbounds=whole)" {save} output.png
+{location} {load} input.bmp {resize} 325% "Resampler: Bicubic" {save} output.png
+{location} {load} input.bmp {resize} auto "Upscaler: LQ 2x" {save} output.png
 {location} {load} input.bmp {script} "MyFilterChain.scr" {save} output.png
 {location} {script} "MyScript.scr"
 
+The category may be left out where it is unambiguous, so this is the same filter as above.
+{location} {load} input.bmp {resize} auto "LQ 2x" {save} output.png
+
 You can load and process multiple files at once by loading after saving again.
-{location} {load}  1.bmp {resize} 10x10 Pixel {save} 1.jpg {load} 2.bmp {resize} 10x10 Pixel {save} 2.jpg
+{location} {load} 1.bmp {resize} 10x10 "Nearest Neighbor" {save} 1.jpg {load} 2.bmp {resize} 10x10 "Nearest Neighbor" {save} 2.jpg
 
 You can also save to multiple files by adding another save parameter.
-{location} {load} 1.bmp {resize} 10x10 Pixel {save} 1.jpg {save} 2.png
+{location} {load} 1.bmp {resize} 10x10 "Nearest Neighbor" {save} 1.jpg {save} 2.png
 
 Even preprocessing using multiple filters is possible by adding another resize parameter.
-{location} {load} 1.bmp {resize} 10x10 Pixel {resize} auto Scale2x {save} 1.png
+{location} {load} 1.bmp {resize} 10x10 "Nearest Neighbor" {resize} auto "Scale 2x" {save} 1.png
 {location} {load} 1.bmp {resize} auto "XBR 3x" {resize} w128 Bicubic {save} 1.png
 
 =========================
@@ -87,4 +95,4 @@ Miscellaneous:
 ==============
 
 For further information, please visit the project's website at:
-  http://code.google.com/p/2dimagefilter/
+  https://github.com/Hawkynt/2dimagefilter

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Our enhanced approach uses flexible similarity functions:
 
 #### Option 3: Command Line Interface
 ```bash
-ImageResizer.exe load input.png resize auto "Upscaler: HQ 2x" save output.png
-ImageResizer.exe load sprite.bmp resize 400% "Upscaler: XBR 3x" save scaled_sprite.png
+ImageResizer.exe /load input.png /resize auto "Upscaler: HQ 2x" /save output.png
+ImageResizer.exe /load sprite.bmp /resize 400% "Upscaler: XBR 3x" /save scaled_sprite.png
 ```
 
 ### Building from Source
@@ -111,6 +111,9 @@ cd 2dimagefilter
 # Build the solution
 dotnet build ImageResizer.slnx -c Release
 
+# Run the tests
+dotnet test ImageResizer.slnx -c Release
+
 # Or build individual projects
 dotnet build ImageResizerLibrary/ImageResizerLibrary.csproj
 dotnet build ImageResizer/ImageResizer.csproj
@@ -121,23 +124,26 @@ dotnet build ImageResizer/ImageResizer.csproj
 ### Command Line Usage
 The application supports powerful command-line scripting.
 
-> **Filter names** use the category prefix shown in the GUI dropdown. Scaling prefixes are directional: `Upscaler: ` (integer upscalers such as HQ, XBR, Eagle, Scale), `Downscaler: ` (integer downscalers, future), `Resampler: ` (bidirectional arbitrary-ratio kernels such as Bicubic, Lanczos), `Downsampler: ` (downscale-only resamplers such as DPID, SSIM Downscale). Other categories: `Filter: `, `Plane: `, `Quantize: `, `Dither: `, `Blend: `. Pass the full label (prefix included) as the filter argument.
+> **Filter names** use the category prefix shown in the GUI dropdown. Scaling prefixes are directional: `Upscaler: ` (integer upscalers such as HQ, XBR, Eagle, Scale), `Downscaler: ` (integer downscalers, future), `Resampler: ` (bidirectional arbitrary-ratio kernels such as Bicubic, Lanczos), `Downsampler: ` (downscale-only resamplers such as DPID, SSIM Downscale). Other categories: `Filter: `, `Plane: `, `Quantize: `, `Dither: `, `Blend: `. Pass the full label as the filter argument; the prefix may be omitted where the bare name is unambiguous, which keeps command lines and `.irs` scripts written before the prefixes existed working.
 
 ```bash
 # Basic usage
-ImageResizer.exe load <input> resize <dimensions> <method> save <output>
+ImageResizer.exe /load <input> /resize <dimensions> <method> /save <output>
 
 # Dimension formats
-resize auto "Upscaler: Scale 2x"          # Auto-detect from algorithm
-resize 320x240 "Resampler: Bicubic"       # Specific dimensions
-resize w128 "Upscaler: HQ 2x"             # Width only (height auto)
-resize h96 "Upscaler: Eagle"              # Height only (width auto)
-resize 200% "Upscaler: XBR 3x"            # Percentage scaling
+/resize auto "Upscaler: Scale 2x"          # Auto-detect from algorithm
+/resize 320x240 "Resampler: Bicubic"       # Specific dimensions
+/resize w128 "Upscaler: HQ 2x"             # Width only (height auto)
+/resize h96 "Upscaler: Eagle"              # Height only (width auto)
+/resize 200% "Upscaler: XBR 3x"            # Percentage scaling
+/resize auto "HQ 2x"                       # Prefix omitted - unambiguous
 
 # Parameter examples
-resize auto "Resampler: Bicubic(radius=1.5,vbounds=wrap)"
-resize 2x2 "Upscaler: HQ 2x(thresholds=1,repeat=2)"
+/resize auto "Resampler: Bicubic(radius=1.5,vbounds=wrap)"
+/resize 2x2 "Upscaler: HQ 2x(thresholds=1)"
 ```
+
+Run `ImageResizer.exe /?` to print the full help including the list of every supported filter method; with no arguments it opens the GUI.
 
 ### Supported Parameters
 - `radius`: Filter radius for resampling kernels

--- a/Tests/ImageResizer.Tests/ImageResizer.Tests.csproj
+++ b/Tests/ImageResizer.Tests/ImageResizer.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Matches the ImageResizer executable under test -->
+    <TargetFramework>net48</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <Platforms>AnyCPU</Platforms>
+    <Prefer32Bit>false</Prefer32Bit>
+    <IsPackable>false</IsPackable>
+    <LangVersion>12</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <Import Project="..\..\VersionSpecificSymbols.Common.prop" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="NUnit" Version="3.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The CLI parser lives in the executable; ImageResizerLibrary supplies the algorithms
+         SupportedManipulators enumerates and is referenced directly so the test host finds it
+         on disk rather than through Costura's embedded-resource resolver. -->
+    <ProjectReference Include="..\..\ImageResizer\ImageResizer.csproj" />
+    <ProjectReference Include="..\..\ImageResizerLibrary\ImageResizerLibrary.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/ImageResizer.Tests/ScriptSerializerTests.cs
+++ b/Tests/ImageResizer.Tests/ScriptSerializerTests.cs
@@ -1,0 +1,508 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing.Extensions.ColorProcessing.Resizing;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+
+using Classes;
+using Classes.ScriptActions;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Covers the script/command line parser. Everything here is reachable from both the CLI and
+  /// the GUI's script loader, and none of it needs a display or an actual image.
+  /// </summary>
+  [TestFixture]
+  public class ScriptSerializerTests {
+
+    #region helpers
+
+    /// <summary>
+    /// Parses a script line into a fresh engine.
+    /// </summary>
+    /// <param name="line">The line.</param>
+    /// <returns>The engine holding the parsed actions.</returns>
+    private static ScriptEngine _Parse(string line) {
+      var engine = new ScriptEngine();
+      ScriptSerializer.LoadFromString(engine, line);
+      return engine;
+    }
+
+    /// <summary>
+    /// Parses a script line and returns the exit code it failed with.
+    /// </summary>
+    /// <param name="line">The line.</param>
+    /// <returns>The exit code.</returns>
+    private static CLIExitCode _ParseExpectingFailure(string line) {
+      var exception = Assert.Throws<ScriptSerializerException>(() => _Parse(line));
+      return exception.ErrorType;
+    }
+
+    /// <summary>
+    /// Parses a script line consisting of a single /resize and returns the resulting command.
+    /// </summary>
+    /// <param name="dimensions">The dimensions argument.</param>
+    /// <param name="filter">The filter argument.</param>
+    /// <returns>The resize command.</returns>
+    private static ResizeCommand _ParseResize(string dimensions, string filter)
+      => (ResizeCommand)_Parse($@"""/resize"" ""{dimensions}"" ""{filter}""").Actions.Single()
+    ;
+
+    /// <summary>
+    /// Quotes arguments the way <see cref="CLI"/> hands a command line to the parser.
+    /// </summary>
+    /// <param name="arguments">The arguments.</param>
+    /// <returns>The script line.</returns>
+    private static string _AsCommandLine(params string[] arguments)
+      => string.Join(" ", arguments.Select(a => $@"""{a}"""))
+    ;
+
+    /// <summary>A manipulator that does nothing; only its identity matters here.</summary>
+    private sealed class FakeManipulator : IImageManipulator {
+      public bool SupportsWidth => false;
+      public bool SupportsHeight => false;
+      public bool SupportsRepetitionCount => false;
+      public bool SupportsGridCentering => false;
+      public bool SupportsThresholds => false;
+      public bool SupportsRadius => false;
+      public bool ChangesResolution => false;
+      public string Description => "fake";
+      public IReadOnlyList<Hawkynt.ColorProcessing.ParameterDescriptor> Parameters => ImageManipulatorDefaults.EmptyParameters;
+      public IImageManipulator CreateWith(IReadOnlyDictionary<string, object> values) => this;
+    }
+
+    private static KeyValuePair<string, IImageManipulator> _Entry(string key, IImageManipulator manipulator)
+      => new KeyValuePair<string, IImageManipulator>(key, manipulator)
+    ;
+
+    #endregion
+
+    #region commands
+
+    [Test]
+    public void EmptyLine_ProducesNoActions() {
+      Assert.That(_Parse(string.Empty).Actions, Is.Empty);
+      Assert.That(_Parse("   ").Actions, Is.Empty);
+    }
+
+    [Test]
+    public void Load_AddsLoadCommandWithFileName() {
+      var actions = _Parse(_AsCommandLine("/load", "in.png")).Actions.ToArray();
+
+      Assert.That(actions[0], Is.InstanceOf<LoadFileCommand>());
+      Assert.That(((LoadFileCommand)actions[0]).FileName, Is.EqualTo("in.png"));
+    }
+
+    [Test]
+    public void Load_KeepsSpacesInQuotedFileNames() {
+      var actions = _Parse(_AsCommandLine("/load", @"C:\my images\in.png")).Actions.ToArray();
+
+      Assert.That(((LoadFileCommand)actions[0]).FileName, Is.EqualTo(@"C:\my images\in.png"));
+    }
+
+    [Test]
+    public void Save_AddsSaveCommandWithFileName() {
+      var actions = _Parse(_AsCommandLine("/save", "out.png")).Actions.ToArray();
+
+      Assert.That(actions[0], Is.InstanceOf<SaveFileCommand>());
+      Assert.That(((SaveFileCommand)actions[0]).FileName, Is.EqualTo("out.png"));
+    }
+
+    [Test]
+    public void StdInAndStdOut_AddTheirCommands() {
+      var actions = _Parse(_AsCommandLine("/stdin", "/stdout")).Actions.ToArray();
+
+      Assert.That(actions.Any(a => a is LoadStdInCommand), Is.True);
+      Assert.That(actions.Any(a => a is SaveStdOutCommand), Is.True);
+    }
+
+    [Test]
+    public void CommandNames_AreCaseInsensitive() {
+      Assert.That(_Parse(_AsCommandLine("/LOAD", "in.png")).Actions.First(), Is.InstanceOf<LoadFileCommand>());
+    }
+
+    [Test]
+    public void FullChain_KeepsCommandOrder() {
+      var actions = _Parse(_AsCommandLine("/load", "in.png", "/resize", "auto", "Upscaler: HQ 2x", "/save", "out.png"))
+        .Actions
+        .Where(a => !(a is NullTransformCommand))
+        .ToArray()
+        ;
+
+      Assert.That(actions.Select(a => a.GetType()), Is.EqualTo(new[] {
+        typeof(LoadFileCommand),
+        typeof(ResizeCommand),
+        typeof(SaveFileCommand),
+      }));
+    }
+
+    [Test]
+    public void UnknownCommand_IsRejected()
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine("/frobnicate", "in.png")), Is.EqualTo(CLIExitCode.UnknownParameter))
+    ;
+
+    [TestCase("/load")]
+    [TestCase("/save")]
+    [TestCase("/script")]
+    public void CommandWithoutItsArgument_IsRejected(string command)
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine(command)), Is.EqualTo(CLIExitCode.TooLessArguments))
+    ;
+
+    [Test]
+    public void ResizeWithoutFilter_IsRejected()
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine("/resize", "auto")), Is.EqualTo(CLIExitCode.TooLessArguments))
+    ;
+
+    #endregion
+
+    #region dimensions
+
+    [Test]
+    public void Auto_LeavesEveryDimensionUnset() {
+      var command = _ParseResize("auto", "Resampler: Bicubic");
+
+      Assert.That(command.Width, Is.EqualTo(0));
+      Assert.That(command.Height, Is.EqualTo(0));
+      Assert.That(command.Percentage, Is.EqualTo(0));
+      Assert.That(command.MaintainAspect, Is.True);
+    }
+
+    [Test]
+    public void WidthOnly_SetsWidthAndKeepsAspect() {
+      var command = _ParseResize("w72", "Resampler: Bicubic");
+
+      Assert.That(command.Width, Is.EqualTo(72));
+      Assert.That(command.Height, Is.EqualTo(0));
+      Assert.That(command.MaintainAspect, Is.True);
+    }
+
+    [Test]
+    public void HeightOnly_SetsHeightAndKeepsAspect() {
+      var command = _ParseResize("h92", "Resampler: Bicubic");
+
+      Assert.That(command.Width, Is.EqualTo(0));
+      Assert.That(command.Height, Is.EqualTo(92));
+      Assert.That(command.MaintainAspect, Is.True);
+    }
+
+    [Test]
+    public void BothDimensions_DropAspectMaintenance() {
+      var command = _ParseResize("72x92", "Resampler: Bicubic");
+
+      Assert.That(command.Width, Is.EqualTo(72));
+      Assert.That(command.Height, Is.EqualTo(92));
+      Assert.That(command.MaintainAspect, Is.False);
+    }
+
+    /// <summary>
+    /// Regression: the percentage group used to capture nothing, so every <c>&lt;p&gt;%</c>
+    /// silently degraded into <c>auto</c>.
+    /// </summary>
+    [TestCase("1%", 1)]
+    [TestCase("100%", 100)]
+    [TestCase("325%", 325)]
+    [TestCase("65535%", 65535)]
+    public void Percentage_IsParsed(string dimensions, int expected) {
+      var command = _ParseResize(dimensions, "Resampler: Bicubic");
+
+      Assert.That(command.Percentage, Is.EqualTo(expected));
+      Assert.That(command.Width, Is.EqualTo(0));
+      Assert.That(command.Height, Is.EqualTo(0));
+    }
+
+    [TestCase("0x0")]
+    [TestCase("65535x65535")]
+    [TestCase("w0")]
+    [TestCase("w65535")]
+    public void DimensionsAtTheWordBoundary_AreAccepted(string dimensions)
+      => Assert.That(() => _ParseResize(dimensions, "Resampler: Bicubic"), Throws.Nothing)
+    ;
+
+    [TestCase("65536x1")]
+    [TestCase("1x65536")]
+    [TestCase("w65536")]
+    [TestCase("h65536")]
+    [TestCase("65536%")]
+    public void DimensionsAboveTheWordBoundary_AreRejected(string dimensions)
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine("/resize", dimensions, "Resampler: Bicubic")), Is.EqualTo(CLIExitCode.CouldNotParseDimensionsAsWord))
+    ;
+
+    /// <summary>
+    /// Regression: the alternation was not grouped, so <c>^</c> and <c>$</c> anchored the first
+    /// and last branch only and anything wrapped around a valid branch was accepted.
+    /// </summary>
+    [TestCase("")]
+    [TestCase("wobble")]
+    [TestCase("junk-w72-junk")]
+    [TestCase("w72x92")]
+    [TestCase("xw72")]
+    [TestCase("72x")]
+    [TestCase("x92")]
+    [TestCase("%")]
+    [TestCase("325 %")]
+    [TestCase("-72x92")]
+    public void MalformedDimensions_AreRejected(string dimensions)
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine("/resize", dimensions, "Resampler: Bicubic")), Is.EqualTo(CLIExitCode.InvalidTargetDimensions))
+    ;
+
+    [TestCase("AUTO")]
+    [TestCase("W72")]
+    [TestCase("72X92")]
+    public void Dimensions_AreCaseInsensitive(string dimensions)
+      => Assert.That(() => _ParseResize(dimensions, "Resampler: Bicubic"), Throws.Nothing)
+    ;
+
+    #endregion
+
+    #region filter names
+
+    [Test]
+    public void FullyQualifiedFilterName_Resolves()
+      => Assert.That(_ParseResize("auto", "Upscaler: HQ 2x").Manipulator, Is.Not.Null)
+    ;
+
+    /// <summary>
+    /// Regression for issue #33: manipulator keys gained a category prefix, which invalidated
+    /// every command line and script written before it existed.
+    /// </summary>
+    [TestCase("HQ 2x")]
+    [TestCase("XBR 3x")]
+    [TestCase("Bicubic")]
+    [TestCase("Scale 2x")]
+    public void FilterNameWithoutItsCategory_StillResolves(string filterName)
+      => Assert.That(_ParseResize("auto", filterName).Manipulator, Is.Not.Null)
+    ;
+
+    [Test]
+    public void FilterNameWithoutItsCategory_ResolvesToTheSameManipulatorAsTheFullName()
+      => Assert.That(_ParseResize("auto", "HQ 2x").Manipulator, Is.SameAs(_ParseResize("auto", "Upscaler: HQ 2x").Manipulator))
+    ;
+
+    [TestCase("hq 2X")]
+    [TestCase("upscaler: HQ 2X")]
+    [TestCase("UPSCALER: hq 2x")]
+    public void FilterNames_AreCaseInsensitive(string filterName)
+      => Assert.That(_ParseResize("auto", filterName).Manipulator, Is.Not.Null)
+    ;
+
+    [TestCase("NoSuchFilter")]
+    [TestCase("NoSuchCategory: HQ 2x")]
+    [TestCase("")]
+    public void UnknownFilter_IsRejected(string filterName)
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine("/resize", "auto", filterName)), Is.EqualTo(CLIExitCode.UnknownFilter))
+    ;
+
+    [Test]
+    public void ExactKeyWins_OverABareNameFromAnotherCategory() {
+      var exact = new FakeManipulator();
+      var other = new FakeManipulator();
+      var manipulators = new[] {
+        _Entry("Filter: Upscaler: Sharpen", other),
+        _Entry("Upscaler: Sharpen", exact),
+      };
+
+      var result = ScriptSerializer.FindManipulator(manipulators, "Upscaler: Sharpen", out var isAmbiguous);
+
+      Assert.That(result, Is.SameAs(exact));
+      Assert.That(isAmbiguous, Is.False);
+    }
+
+    [Test]
+    public void BareNameOfferedByTwoCategories_IsAmbiguous() {
+      var manipulators = new[] {
+        _Entry("Upscaler: Sharpen", new FakeManipulator()),
+        _Entry("Filter: Sharpen", new FakeManipulator()),
+      };
+
+      var result = ScriptSerializer.FindManipulator(manipulators, "Sharpen", out var isAmbiguous);
+
+      Assert.That(result, Is.Null);
+      Assert.That(isAmbiguous, Is.True);
+    }
+
+    [Test]
+    public void AmbiguousFilter_IsReportedAsSuchByTheParser() {
+      // the real registry has no ambiguous bare name, so this pins the plumbing rather than the data
+      var manipulators = new[] {
+        _Entry("Upscaler: Sharpen", new FakeManipulator()),
+        _Entry("Filter: Sharpen", new FakeManipulator()),
+      };
+
+      ScriptSerializer.FindManipulator(manipulators, "Sharpen", out var isAmbiguous);
+
+      Assert.That(isAmbiguous, Is.True);
+    }
+
+    [Test]
+    public void EveryRegisteredFilter_IsReachableByItsFullKey() {
+      var unreachable = SupportedManipulators.MANIPULATORS
+        .Where(pair => !ReferenceEquals(ScriptSerializer.FindManipulator(SupportedManipulators.MANIPULATORS, pair.Key, out _), pair.Value))
+        .Select(pair => pair.Key)
+        .ToArray()
+        ;
+
+      Assert.That(unreachable, Is.Empty);
+    }
+
+    #endregion
+
+    #region filter parameters
+
+    [Test]
+    public void NoParameters_YieldTheDefaults() {
+      var command = _ParseResize("auto", "Resampler: Bicubic");
+
+      Assert.That(command.Count, Is.EqualTo(1));
+      Assert.That(command.Radius, Is.EqualTo(1f));
+      Assert.That(command.UseThresholds, Is.True);
+      Assert.That(command.UseCenteredGrid, Is.True);
+      Assert.That(command.HorizontalBph, Is.EqualTo(OutOfBoundsMode.ConstantExtension));
+      Assert.That(command.VerticalBph, Is.EqualTo(OutOfBoundsMode.ConstantExtension));
+    }
+
+    [Test]
+    public void BareNumberParameter_IsTheRepetitionCount()
+      => Assert.That(_ParseResize("auto", "Upscaler: HQ 2x(3)").Count, Is.EqualTo(3))
+    ;
+
+    [TestCase("repeat=1", 1)]
+    [TestCase("repeat=255", 255)]
+    public void RepeatAtItsBoundaries_IsAccepted(string parameters, int expected)
+      => Assert.That(_ParseResize("auto", $"Resampler: Bicubic({parameters})").Count, Is.EqualTo(expected))
+    ;
+
+    [TestCase("repeat=256")]
+    [TestCase("repeat=-1")]
+    [TestCase("repeat=x")]
+    public void RepeatOutsideAByte_IsRejected(string parameters)
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine("/resize", "auto", $"Resampler: Bicubic({parameters})")), Is.EqualTo(CLIExitCode.CouldNotParseParameterAsByte))
+    ;
+
+    [Test]
+    public void Radius_IsParsedInvariantOfTheCurrentCulture() {
+      var previous = Thread.CurrentThread.CurrentCulture;
+      Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+      try {
+        Assert.That(_ParseResize("auto", "Resampler: Bicubic(radius=1.5)").Radius, Is.EqualTo(1.5f));
+      } finally {
+        Thread.CurrentThread.CurrentCulture = previous;
+      }
+    }
+
+    [Test]
+    public void NonNumericRadius_IsRejected()
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine("/resize", "auto", "Resampler: Bicubic(radius=abc)")), Is.EqualTo(CLIExitCode.CouldNotParseParameterAsFloat))
+    ;
+
+    [TestCase("const", OutOfBoundsMode.ConstantExtension)]
+    [TestCase("half", OutOfBoundsMode.HalfSampleSymmetric)]
+    [TestCase("whole", OutOfBoundsMode.WholeSampleSymmetric)]
+    [TestCase("wrap", OutOfBoundsMode.WrapAround)]
+    [TestCase("transparent", OutOfBoundsMode.FlatColor)]
+    public void EveryOutOfBoundsMode_IsUnderstood(string value, OutOfBoundsMode expected) {
+      var command = _ParseResize("auto", $"Resampler: Bicubic(hbounds={value},vbounds={value})");
+
+      Assert.That(command.HorizontalBph, Is.EqualTo(expected));
+      Assert.That(command.VerticalBph, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void UnknownOutOfBoundsMode_IsRejected()
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine("/resize", "auto", "Resampler: Bicubic(vbounds=nope)")), Is.EqualTo(CLIExitCode.InvalidOutOfBoundsMode))
+    ;
+
+    [TestCase("thresholds=0", false)]
+    [TestCase("thresholds=1", true)]
+    public void Thresholds_AreParsed(string parameters, bool expected)
+      => Assert.That(_ParseResize("auto", $"Resampler: Bicubic({parameters})").UseThresholds, Is.EqualTo(expected))
+    ;
+
+    [TestCase("centered=0", false)]
+    [TestCase("centered=1", true)]
+    public void CenteredGrid_IsParsed(string parameters, bool expected)
+      => Assert.That(_ParseResize("auto", $"Resampler: Bicubic({parameters})").UseCenteredGrid, Is.EqualTo(expected))
+    ;
+
+    [Test]
+    public void SeveralParameters_AreAllApplied() {
+      var command = _ParseResize("auto", "Resampler: Bicubic(radius=2.25, repeat=4, vbounds=wrap, hbounds=half, thresholds=0, centered=0)");
+
+      Assert.That(command.Radius, Is.EqualTo(2.25f));
+      Assert.That(command.Count, Is.EqualTo(4));
+      Assert.That(command.VerticalBph, Is.EqualTo(OutOfBoundsMode.WrapAround));
+      Assert.That(command.HorizontalBph, Is.EqualTo(OutOfBoundsMode.HalfSampleSymmetric));
+      Assert.That(command.UseThresholds, Is.False);
+      Assert.That(command.UseCenteredGrid, Is.False);
+    }
+
+    [Test]
+    public void UnknownParameter_IsRejected()
+      => Assert.That(_ParseExpectingFailure(_AsCommandLine("/resize", "auto", "Resampler: Bicubic(bogus=1)")), Is.EqualTo(CLIExitCode.UnknownParameter))
+    ;
+
+    #endregion
+
+    #region round trip
+
+    /// <summary>
+    /// Note that a manipulator's capability flags decide what gets written: parameters it does
+    /// not advertise (radius on a resampler, repetitions on a fixed-factor upscaler) are dropped
+    /// by <see cref="ScriptSerializer.SerializeState"/> and so are not round-trip material.
+    /// </summary>
+    [Test]
+    public void SerializedState_ParsesBackIntoTheSameCommands() {
+      var original = _Parse(_AsCommandLine("/load", "in.png", "/resize", "72x92", "Resampler: Bicubic(vbounds=wrap,hbounds=half,centered=0)", "/save", "out.png"));
+
+      var reparsed = new ScriptEngine();
+      foreach (var line in ScriptSerializer.SerializeState(original).Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
+        ScriptSerializer.LoadFromString(reparsed, line);
+
+      var before = original.Actions.OfType<ResizeCommand>().Single();
+      var after = reparsed.Actions.OfType<ResizeCommand>().Single();
+
+      Assert.That(after.Manipulator, Is.SameAs(before.Manipulator));
+      Assert.That(after.Width, Is.EqualTo(before.Width));
+      Assert.That(after.Height, Is.EqualTo(before.Height));
+      Assert.That(after.MaintainAspect, Is.EqualTo(before.MaintainAspect));
+      Assert.That(after.VerticalBph, Is.EqualTo(before.VerticalBph));
+      Assert.That(after.HorizontalBph, Is.EqualTo(before.HorizontalBph));
+      Assert.That(after.UseCenteredGrid, Is.EqualTo(before.UseCenteredGrid));
+    }
+
+    [Test]
+    public void SerializedFilterNames_AreFullyQualifiedAndParseBack() {
+      var original = _Parse(_AsCommandLine("/resize", "auto", "HQ 2x"));
+
+      var serialized = ScriptSerializer.SerializeState(original);
+
+      Assert.That(serialized, Does.Contain("Upscaler: HQ 2x"));
+      Assert.That(() => _Parse(serialized), Throws.Nothing);
+    }
+
+    #endregion
+
+  }
+}


### PR DESCRIPTION
Closes #33.

The report was accurate and understated — there were three independent regressions, and the first one broke *every* command line.

## 1. Every run aborted in the post-load diagnostics

The load/save log lines resolved the image format with:

```csharp
ImageCodecInfo.GetImageDecoders().First(d => d.FormatID == engine.GdiSource.RawFormat.Guid)
```

Since `LoadFileCommand` started copying loaded files into a standalone `Bitmap`, the source's `RawFormat` is `MemoryBmp`, which no decoder claims — `First()` threw and the run ended in `RuntimeError` before anything was written. Even `/load in.png /save out.png` died there.

Details now come from the file rather than the in-memory copy, and the block is guarded: diagnostics must never be able to abort a pipeline. The filter-name lookup in the pre-action had the same `First()` hazard.

## 2. Filter names lost their legacy bare form

Manipulator keys gained the category they are registered under (`"Upscaler: HQ 2x"`), which invalidated every command line and `.irs` script written before that scheme existed — they name the filter alone and got `UnknownFilter` back.

Names now resolve against the full key first and against everything after the first `": "` second, so `"HQ 2x"` and `"Upscaler: HQ 2x"` both work. The prefixed form stays canonical and is what serialization writes. A bare name that two categories both provide reports the new `AmbiguousFilter` code instead of silently picking one.

## 3. `/resize <p>%` silently resized to auto

The dimensions pattern had two defects. Its alternation was never grouped, so `^` and `$` anchored the first and last branch only and `junk-w72-junk` matched on the unanchored middle. And the percentage branch captured an *empty* group, so the digits were discarded and every `<p>%` fell through to width 0 / height 0 — which the resize command reads as `auto`.

## Also

- Parse failures now print their cause. Previously a malformed command line answered with nothing but the help text, which is the behaviour reported as *"it displays the help text and does nothing"*.
- `/?` is a real help switch (also `-?`, `--?`, `/h`, `-h`, `/help`, `--help`). Asking for help used to fall through to the unknown-parameter branch and exit 1.
- The shipped help examples used names dropped along the way (`Pixel`, `Scale2x`, `LQ 2x Smart`), and the README spelled the commands without their leading slashes — not one of its examples could run.
- Dead `code.google.com` project link replaced.

## Tests

Nothing in this repository was under test, which is how three parser regressions shipped unnoticed. Adds `Tests/ImageResizer.Tests` (NUnit 3, matching the FrameworkExtensions house layout) with **81 cases**: commands and their argument arity, dimension forms with their `word` boundaries (65535/65536), filter-name resolution in both spellings, the parameter list including culture-invariant floats, and the error path of each exit code. CI runs `dotnet test` instead of announcing that no tests exist.

## Verification

- The reporter's exact command produces a correct 32x32 PNG, exit 0.
- All 12 examples in the help text execute successfully.
- `dotnet build` 0 errors, `dotnet test` 81/81 green.

Depends on #34 (`.slnx` migration).