### PR TITLE
# pinned AssemblyVersion/FileVersion overrode the CI version stamp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,16 @@ dropdown and README in sync.
 Stable releases are **manual** (`gh workflow run release.yml`) — never cut
 one unless explicitly asked.
 
+## Versioning
+
+- Each project declares a **three-part base** in `<Version>` and nothing else.
+  The fourth part (revision) belongs to CI: `version.pl --stamp` appends the
+  commit count of the folder that declares the version.
+- **Never** pin `<AssemblyVersion>` or `<FileVersion>` — they derive from
+  `<Version>`, and pinning them silently overrides the stamp, which is how the
+  binaries ended up reporting 1.1.3.3 while releases were named 1.1.3.21.
+- Bump the base by hand only for a deliberate major/minor/patch release.
+
 ## Code conventions
 
 - Latest C# features; pixel kernels are hot paths — measure before and

--- a/ImageResizer/ImageResizer.csproj
+++ b/ImageResizer/ImageResizer.csproj
@@ -26,8 +26,10 @@
     <Company>»SynthelicZ«</Company>
     <Product>ImageResizer</Product>
     <Copyright>Copyright © 2008-2019 Hawkynt</Copyright>
-    <AssemblyVersion>1.1.3.3</AssemblyVersion>
-    <FileVersion>1.1.3.3</FileVersion>
+    <!-- Base version only. The revision is appended during CI by
+         .github/workflows/scripts/version.pl; AssemblyVersion and FileVersion derive from it,
+         so never pin those here or the stamp has no effect on the produced binaries. -->
+    <Version>1.1.3</Version>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/ImageResizerLibrary/ImageResizerLibrary.csproj
+++ b/ImageResizerLibrary/ImageResizerLibrary.csproj
@@ -6,8 +6,6 @@
     <Company>»SynthelicZ«</Company>
     <Product>ImageResizer</Product>
     <Copyright>Copyright © 2008-2019 Hawkynt</Copyright>
-    <AssemblyVersion>1.1.3.3</AssemblyVersion>
-    <FileVersion>1.1.3.3</FileVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>12</LangVersion>

--- a/PixelArtScalingPlugin/PixelArtScaling.csproj
+++ b/PixelArtScalingPlugin/PixelArtScaling.csproj
@@ -8,8 +8,8 @@
     <Product>PixelArtScalingPlugin</Product>
     <Description>Manipulates images using the 2dimagefilter library.</Description>
     <Copyright>Copyright ©2008-2019 Hawkynt</Copyright>
-    <AssemblyVersion>1.1.3.3</AssemblyVersion>
-    <FileVersion>1.1.3.3</FileVersion>
+    <!-- Base version only; the revision is stamped by CI. See ImageResizer.csproj. -->
+    <Version>1.1.3</Version>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>9</LangVersion>


### PR DESCRIPTION
Auto-versioning was inert: releases were named from one number while the binaries reported another.

## Cause

`version.pl --stamp` writes the composed version into `<Version>`, but all three projects also pinned `<AssemblyVersion>` and `<FileVersion>` to `1.1.3.3` — and pinned values win. The exe therefore reported `v1.1.3.3` no matter what, while the nightly it came from was published as `1.1.3.21`. That mismatch is visible in the help header quoted in #33.

Worse, `ImageResizer.csproj` and `PixelArtScaling.csproj` declared no `<Version>` at all, so the stamper skipped them entirely and the release version was taken from the library instead of the executable.

## Change

All three projects now declare the three-part base in `<Version>` only and let `AssemblyVersion`/`FileVersion` derive from it. The primary version source becomes `ImageResizer.csproj`, so the release name follows the executable.

`AGENTS.md` gains a Versioning section: the revision belongs to CI and must never be pinned. That missing rule is what allowed this to drift.

## Verification

Before — `version.pl --list` saw one project:

```
ImageResizerLibrary/ImageResizerLibrary.csproj   1.1.3.21
```

After:

```
ImageResizer/ImageResizer.csproj                 1.1.3.68
ImageResizerLibrary/ImageResizerLibrary.csproj   1.1.3.21
PixelArtScalingPlugin/PixelArtScaling.csproj     1.1.3.12
```

And the stamp now reaches the binary — after `version.pl --stamp` the built exe reports `FileVersion 1.1.3.69`, where it was previously frozen at `1.1.3.3` forever.

## Note

`version.pl` derives each project's revision from its own folder's commit count, so the three assemblies get different revisions by design. Happy to switch them to a single shared number via a root `VERSION` file if that is preferred.