### PR TITLE
+ unit and end-to-end coverage across the application

### DIFF
--- a/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
+++ b/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
@@ -1,0 +1,413 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+using Classes;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// End-to-end coverage: runs the real <c>ImageResizer.exe</c> with real command lines and checks
+  /// what it wrote and what it exited with. This is the layer that broke in issue #33 - every unit
+  /// underneath was fine, the assembled program was not.
+  /// <para>
+  /// No pixel comparison happens here; these tests assert dimensions, container format, exit codes
+  /// and diagnostics. Visual regressions need reference images, which is a separate concern.
+  /// </para>
+  /// </summary>
+  [TestFixture]
+  public class CommandLineEndToEndTests {
+
+    /// <summary>A single run must never outlive this; a hung child would otherwise hang the suite.</summary>
+    private const int _TIMEOUT_MILLISECONDS = 60000;
+
+    private static readonly string _EXECUTABLE = Path.Combine(
+      Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath) ?? ".",
+      "ImageResizer.exe"
+    );
+
+    private TemporaryDirectory _directory;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+      => Assert.That(File.Exists(_EXECUTABLE), Is.True, $"the executable under test is missing at {_EXECUTABLE}")
+    ;
+
+    [SetUp]
+    public void SetUp() => this._directory = new TemporaryDirectory();
+
+    [TearDown]
+    public void TearDown() => this._directory.Dispose();
+
+    #region helpers
+
+    /// <summary>The outcome of one process run.</summary>
+    private sealed class RunResult {
+      public int ExitCode { get; set; }
+      public string StandardOutput { get; set; }
+      public string StandardError { get; set; }
+
+      public CLIExitCode Code => (CLIExitCode)this.ExitCode;
+    }
+
+    /// <summary>
+    /// Runs the executable with the given arguments in the scratch directory.
+    /// </summary>
+    /// <param name="arguments">The arguments, each quoted as needed.</param>
+    /// <returns>The outcome.</returns>
+    private RunResult _Run(params string[] arguments) {
+      var startInfo = new ProcessStartInfo(_EXECUTABLE) {
+        Arguments = string.Join(" ", arguments.Select(_Quote)),
+        WorkingDirectory = this._directory.Path,
+        UseShellExecute = false,
+        CreateNoWindow = true,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+      };
+
+      using (var process = Process.Start(startInfo)) {
+        // read both pipes before waiting, or a full buffer deadlocks the child
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+
+        if (!process.WaitForExit(_TIMEOUT_MILLISECONDS)) {
+          process.Kill();
+          Assert.Fail("the executable did not terminate within {0} ms", _TIMEOUT_MILLISECONDS);
+        }
+
+        return new RunResult {
+          ExitCode = process.ExitCode,
+          StandardOutput = standardOutput.Result,
+          StandardError = standardError.Result,
+        };
+      }
+    }
+
+    private static string _Quote(string argument)
+      => argument.IndexOf(' ') < 0 ? argument : "\"" + argument + "\""
+    ;
+
+    /// <summary>Writes a source image into the scratch directory and returns its bare file name.</summary>
+    private string _Source(string fileName = "in.png", int width = 16, int height = 16) {
+      TestBitmaps.WriteTo(this._directory.File(fileName), width, height);
+      return fileName;
+    }
+
+    private Size _SizeOf(string fileName) => TestBitmaps.SizeOf(this._directory.File(fileName));
+
+    private bool _Exists(string fileName) => File.Exists(this._directory.File(fileName));
+
+    #endregion
+
+    #region happy path
+
+    [Test]
+    public void LoadAndSave_CopiesTheImageThrough() {
+      var result = this._Run("/load", this._Source(), "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(16, 16)));
+    }
+
+    /// <summary>Regression for issue #33 - this exact command line used to exit with RuntimeError.</summary>
+    [Test]
+    public void TheCommandLineFromIssue33_Works() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "HQ 2x", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(32, 32)));
+    }
+
+    [TestCase("Upscaler: HQ 2x", 32, 32)]
+    [TestCase("HQ 2x", 32, 32)]
+    [TestCase("Upscaler: XBR 3x", 48, 48)]
+    [TestCase("Upscaler: xBRZ 4x", 64, 64)]
+    [TestCase("Upscaler: Scale 2x", 32, 32)]
+    [TestCase("Upscaler: Eagle", 32, 32)]
+    public void FixedFactorUpscalers_ProduceTheirFactor(string filter, int expectedWidth, int expectedHeight) {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", filter, "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(expectedWidth, expectedHeight)));
+    }
+
+    [TestCase("72x92", 72, 92)]
+    [TestCase("w32", 32, 32)]
+    [TestCase("h48", 48, 48)]
+    [TestCase("325%", 52, 52)]
+    [TestCase("100%", 16, 16)]
+    public void EveryDimensionForm_ReachesItsTarget(string dimensions, int expectedWidth, int expectedHeight) {
+      var result = this._Run("/load", this._Source(), "/resize", dimensions, "Resampler: Bicubic", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(expectedWidth, expectedHeight)));
+    }
+
+    [Test]
+    public void FiltersChain_LeftToRight() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "XBR 3x", "/resize", "w128", "Bicubic", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._SizeOf("out.png").Width, Is.EqualTo(128));
+    }
+
+    [Test]
+    public void SeveralSavesInOneRun_AllProduceFiles() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "HQ 2x", "/save", "a.png", "/save", "b.bmp");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._Exists("a.png"), Is.True);
+      Assert.That(this._Exists("b.bmp"), Is.True);
+    }
+
+    [Test]
+    public void SeveralFilesInOneRun_AreProcessedIndependently() {
+      this._Source("one.png", 8, 8);
+      this._Source("two.png", 12, 12);
+
+      var result = this._Run(
+        "/load", "one.png", "/resize", "auto", "HQ 2x", "/save", "one-out.png",
+        "/load", "two.png", "/resize", "auto", "HQ 2x", "/save", "two-out.png"
+      );
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._SizeOf("one-out.png"), Is.EqualTo(new Size(16, 16)));
+      Assert.That(this._SizeOf("two-out.png"), Is.EqualTo(new Size(24, 24)));
+    }
+
+    [TestCase("out.png")]
+    [TestCase("out.bmp")]
+    [TestCase("out.gif")]
+    [TestCase("out.jpg")]
+    [TestCase("out.tif")]
+    public void TheOutputExtension_PicksTheContainerFormat(string target) {
+      var result = this._Run("/load", this._Source(), "/save", target);
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(TestBitmaps.RawFormatOf(this._directory.File(target)), Is.EqualTo(TestBitmaps.FormatFor(target)));
+    }
+
+    [Test]
+    public void APathWithSpaces_IsHandled() {
+      this._Source("my source.png");
+
+      var result = this._Run("/load", "my source.png", "/save", "my target.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._Exists("my target.png"), Is.True);
+    }
+
+    [Test]
+    public void FilterParameters_AreAccepted() {
+      var result = this._Run("/load", this._Source(), "/resize", "32x32", "Resampler: Bicubic(vbounds=wrap,hbounds=wrap,centered=0)", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(32, 32)));
+    }
+
+    #endregion
+
+    #region scripts
+
+    [Test]
+    public void AScriptFile_RunsItsCommands() {
+      this._Source();
+      File.WriteAllText(this._directory.File("chain.irs"), "/load \"in.png\"\r\n/resize auto \"Upscaler: XBR 4x\"\r\n/save \"out.png\"\r\n");
+
+      var result = this._Run("/script", "chain.irs");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(64, 64)));
+    }
+
+    [Test]
+    public void AScriptFile_ComposesWithSurroundingCommands() {
+      this._Source();
+      File.WriteAllText(this._directory.File("filter.irs"), "/resize auto \"Upscaler: HQ 2x\"\r\n");
+
+      var result = this._Run("/load", "in.png", "/script", "filter.irs", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(32, 32)));
+    }
+
+    [Test]
+    public void ABadLineInAScript_IsReportedWithItsOrigin() {
+      File.WriteAllText(this._directory.File("bad.irs"), "/resize auto \"NoSuchFilter\"\r\n");
+
+      var result = this._Run("/script", "bad.irs");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.UnknownFilter));
+      Assert.That(result.StandardOutput, Does.Contain("bad.irs"));
+    }
+
+    #endregion
+
+    #region help
+
+    [TestCase("/?")]
+    [TestCase("-?")]
+    [TestCase("/help")]
+    [TestCase("--help")]
+    [TestCase("/h")]
+    public void EveryHelpSwitch_PrintsTheHelpAndSucceeds(string switchText) {
+      var result = this._Run(switchText);
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK));
+      Assert.That(result.StandardOutput, Does.Contain("How to use"));
+    }
+
+    [Test]
+    public void TheHelp_ListsTheSupportedFilters() {
+      var result = this._Run("/?");
+
+      Assert.That(result.StandardOutput, Does.Contain("Supported filter methods"));
+      Assert.That(result.StandardOutput, Does.Contain("Upscaler: HQ 2x"));
+    }
+
+    [Test]
+    public void TheHelp_DoesNotAnnounceAnError() {
+      var result = this._Run("/?");
+
+      Assert.That(result.StandardOutput, Does.Not.Contain("ERROR"));
+    }
+
+    #endregion
+
+    #region failure paths
+
+    [Test]
+    public void AnUnknownCommand_IsRejectedAndExplained() {
+      var result = this._Run("/frobnicate", "in.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.UnknownParameter));
+      Assert.That(result.StandardOutput, Does.Contain("ERROR"));
+    }
+
+    [Test]
+    public void AnUnknownFilter_IsRejectedAndExplained() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "NoSuchFilter", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.UnknownFilter));
+      Assert.That(result.StandardOutput, Does.Contain("ERROR"));
+      Assert.That(this._Exists("out.png"), Is.False, "nothing may be written when the script never parsed");
+    }
+
+    // CLIExitCode is internal, so it cannot appear in a public signature - the expectation
+    // travels as its numeric value instead.
+    [TestCase("wobble", (int)CLIExitCode.InvalidTargetDimensions)]
+    [TestCase("w72x92", (int)CLIExitCode.InvalidTargetDimensions)]
+    [TestCase("65536x1", (int)CLIExitCode.CouldNotParseDimensionsAsWord)]
+    public void MalformedDimensions_AreRejected(string dimensions, int expected) {
+      var result = this._Run("/load", this._Source(), "/resize", dimensions, "Bicubic", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo((CLIExitCode)expected));
+    }
+
+    [Test]
+    public void AMissingArgument_IsRejected() {
+      var result = this._Run("/load");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.TooLessArguments));
+    }
+
+    [Test]
+    public void AnUnknownFilterParameter_IsRejected() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "Bicubic(bogus=1)", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.UnknownParameter));
+    }
+
+    [Test]
+    public void AnInvalidOutOfBoundsMode_IsRejected() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "Bicubic(vbounds=nope)", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.InvalidOutOfBoundsMode));
+    }
+
+    [Test]
+    public void AMissingSourceFile_FailsAtRuntimeWithoutWritingAnything() {
+      var result = this._Run("/load", "absent.png", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.RuntimeError));
+      Assert.That(this._Exists("out.png"), Is.False);
+    }
+
+    [Test]
+    public void ASourceThatIsNotAnImage_FailsAtRuntime() {
+      File.WriteAllText(this._directory.File("garbage.png"), "not an image");
+
+      var result = this._Run("/load", "garbage.png", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.RuntimeError));
+    }
+
+    [Test]
+    public void SavingWithNothingLoaded_FailsAtRuntime() {
+      var result = this._Run("/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.RuntimeError));
+    }
+
+    [Test]
+    public void AFailingRun_StillPrintsTheHelpSoTheUserCanRecover() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "NoSuchFilter");
+
+      Assert.That(result.StandardOutput, Does.Contain("How to use"));
+    }
+
+    #endregion
+
+    #region diagnostics
+
+    [Test]
+    public void TheRunEchoesTheScriptItIsAboutToExecute() {
+      var result = this._Run("/load", this._Source(), "/save", "out.png");
+
+      Assert.That(result.StandardOutput, Does.Contain("Executing the following script"));
+    }
+
+    [Test]
+    public void LoadDiagnostics_ReportTheRealContainerFormat() {
+      var result = this._Run("/load", this._Source(), "/save", "out.png");
+
+      Assert.That(result.StandardOutput, Does.Contain("Type   : PNG"), "MemoryBmp here would mean the in-memory copy is being described");
+      Assert.That(result.StandardOutput, Does.Not.Contain("details unavailable"));
+    }
+
+    [Test]
+    public void ResizeDiagnostics_NameTheFilterThatRan() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "HQ 2x", "/save", "out.png");
+
+      Assert.That(result.StandardOutput, Does.Contain("Upscaler: HQ 2x"), "the canonical name, not the abbreviation that was typed");
+    }
+
+    #endregion
+
+  }
+}

--- a/Tests/ImageResizer.Tests/ConfigTests.cs
+++ b/Tests/ImageResizer.Tests/ConfigTests.cs
@@ -1,0 +1,193 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System.IO;
+using System.Windows.Forms;
+using System.Xml;
+
+using Classes;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Covers <see cref="Config"/> persistence. The settings are static, so every test resets them.
+  /// </summary>
+  [TestFixture]
+  public class ConfigTests {
+
+    private TemporaryDirectory _directory;
+
+    [SetUp]
+    public void SetUp() {
+      this._directory = new TemporaryDirectory();
+      _Reset();
+    }
+
+    [TearDown]
+    public void TearDown() {
+      _Reset();
+      this._directory.Dispose();
+    }
+
+    private static void _Reset() {
+      Config.LastLoadDirectory = null;
+      Config.LastSaveDirectory = null;
+      Config.SourceSizeMode = null;
+      Config.TargetSizeMode = null;
+    }
+
+    #region round trip
+
+    [Test]
+    public void EverySetting_SurvivesASaveLoadCycle() {
+      var file = this._directory.File("config.xml");
+      Config.LastLoadDirectory = @"C:\loads";
+      Config.LastSaveDirectory = @"C:\saves";
+      Config.SourceSizeMode = PictureBoxSizeMode.Zoom;
+      Config.TargetSizeMode = PictureBoxSizeMode.CenterImage;
+      Config.Save(file);
+      _Reset();
+
+      Config.Load(file);
+
+      Assert.That(Config.LastLoadDirectory, Is.EqualTo(@"C:\loads"));
+      Assert.That(Config.LastSaveDirectory, Is.EqualTo(@"C:\saves"));
+      Assert.That(Config.SourceSizeMode, Is.EqualTo(PictureBoxSizeMode.Zoom));
+      Assert.That(Config.TargetSizeMode, Is.EqualTo(PictureBoxSizeMode.CenterImage));
+    }
+
+    [Test]
+    public void UnsetSettings_SaveAndLoadAsUnset() {
+      var file = this._directory.File("config.xml");
+
+      Config.Save(file);
+      Config.Load(file);
+
+      Assert.That(Config.LastLoadDirectory, Is.Null);
+      Assert.That(Config.SourceSizeMode, Is.Null);
+    }
+
+    [Test]
+    public void Save_ProducesReadableXml() {
+      var file = this._directory.File("config.xml");
+      Config.LastSaveDirectory = @"C:\saves";
+
+      Config.Save(file);
+
+      Assert.That(File.ReadAllText(file), Does.Contain("Configuration").And.Contain(@"C:\saves"));
+    }
+
+    [Test]
+    public void PathsWithXmlSpecialCharacters_SurviveTheRoundTrip() {
+      var file = this._directory.File("config.xml");
+      Config.LastLoadDirectory = @"C:\a&b\<c>\""d""";
+      Config.Save(file);
+      _Reset();
+
+      Config.Load(file);
+
+      Assert.That(Config.LastLoadDirectory, Is.EqualTo(@"C:\a&b\<c>\""d"""));
+    }
+
+    #endregion
+
+    #region tolerated input
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void LoadingAnEmptyPath_IsIgnored(string path) {
+      Assert.That(() => Config.Load(path), Throws.Nothing);
+      Assert.That(Config.LastLoadDirectory, Is.Null);
+    }
+
+    [Test]
+    public void LoadingAMissingFile_IsIgnored() {
+      Assert.That(() => Config.Load(this._directory.File("absent.xml")), Throws.Nothing);
+      Assert.That(Config.LastLoadDirectory, Is.Null);
+    }
+
+    [Test]
+    public void AForeignRootElement_IsIgnored() {
+      var file = this._directory.File("other.xml");
+      File.WriteAllText(file, @"<SomethingElse><LastLoadDirectory value=""C:\x"" /></SomethingElse>");
+
+      Config.Load(file);
+
+      Assert.That(Config.LastLoadDirectory, Is.Null);
+    }
+
+    [Test]
+    public void UnknownElements_AreSkippedWithoutLosingTheKnownOnes() {
+      var file = this._directory.File("config.xml");
+      File.WriteAllText(file, @"<Configuration><Bogus value=""1"" /><LastLoadDirectory value=""C:\x"" /></Configuration>");
+
+      Config.Load(file);
+
+      Assert.That(Config.LastLoadDirectory, Is.EqualTo(@"C:\x"));
+    }
+
+    [Test]
+    public void ElementsWithoutAValueAttribute_AreSkipped() {
+      var file = this._directory.File("config.xml");
+      File.WriteAllText(file, @"<Configuration><LastLoadDirectory /></Configuration>");
+
+      Config.Load(file);
+
+      Assert.That(Config.LastLoadDirectory, Is.Null);
+    }
+
+    [Test]
+    public void AnUnparseableSizeMode_LeavesTheSettingUnset() {
+      var file = this._directory.File("config.xml");
+      File.WriteAllText(file, @"<Configuration><SourceSizeMode value=""NotAMode"" /></Configuration>");
+
+      Config.Load(file);
+
+      Assert.That(Config.SourceSizeMode, Is.Null);
+    }
+
+    [Test]
+    public void ElementNames_AreMatchedCaseInsensitively() {
+      var file = this._directory.File("config.xml");
+      File.WriteAllText(file, @"<configuration><lastloaddirectory value=""C:\x"" /></configuration>");
+
+      Config.Load(file);
+
+      Assert.That(Config.LastLoadDirectory, Is.EqualTo(@"C:\x"));
+    }
+
+    #endregion
+
+    #region rejected input
+
+    [Test]
+    public void MalformedXml_Throws() {
+      var file = this._directory.File("broken.xml");
+      File.WriteAllText(file, "<Configuration><unclosed>");
+
+      Assert.That(() => Config.Load(file), Throws.InstanceOf<XmlException>());
+    }
+
+    #endregion
+
+  }
+}

--- a/Tests/ImageResizer.Tests/SaveHelperTests.cs
+++ b/Tests/ImageResizer.Tests/SaveHelperTests.cs
@@ -1,0 +1,117 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System.Drawing.Imaging;
+using System.IO;
+
+using Classes;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Covers <see cref="CLI.SaveHelper"/>: the extension-to-encoder mapping and the failure codes
+  /// it reports instead of throwing.
+  /// </summary>
+  [TestFixture]
+  public class SaveHelperTests {
+
+    private TemporaryDirectory _directory;
+
+    [SetUp]
+    public void SetUp() => this._directory = new TemporaryDirectory();
+
+    [TearDown]
+    public void TearDown() => this._directory.Dispose();
+
+    [TestCase("out.png", "Png")]
+    [TestCase("out.bmp", "Bmp")]
+    [TestCase("out.gif", "Gif")]
+    [TestCase("out.tif", "Tiff")]
+    [TestCase("out.jpg", "Jpeg")]
+    [TestCase("out.jpeg", "Jpeg")]
+    public void Extension_PicksTheEncoder(string fileName, string expectedFormat) {
+      var file = this._directory.File(fileName);
+
+      using (var bitmap = TestBitmaps.Create())
+        Assert.That(CLI.SaveHelper(file, bitmap), Is.EqualTo(CLIExitCode.OK));
+
+      Assert.That(TestBitmaps.RawFormatOf(file), Is.EqualTo(typeof(ImageFormat).GetProperty(expectedFormat).GetValue(null)));
+    }
+
+    [TestCase("out.PNG")]
+    [TestCase("out.JPG")]
+    public void ExtensionMatching_IsCaseInsensitive(string fileName) {
+      var file = this._directory.File(fileName);
+
+      using (var bitmap = TestBitmaps.Create())
+        Assert.That(CLI.SaveHelper(file, bitmap), Is.EqualTo(CLIExitCode.OK));
+    }
+
+    [TestCase("out.xyz")]
+    [TestCase("out")]
+    public void UnknownOrMissingExtension_FallsBackToPng(string fileName) {
+      var file = this._directory.File(fileName);
+
+      using (var bitmap = TestBitmaps.Create())
+        CLI.SaveHelper(file, bitmap);
+
+      Assert.That(TestBitmaps.RawFormatOf(file), Is.EqualTo(ImageFormat.Png));
+    }
+
+    [Test]
+    public void NothingToSave_IsReportedNotThrown()
+      => Assert.That(CLI.SaveHelper(this._directory.File("out.png"), null), Is.EqualTo(CLIExitCode.NothingToSave))
+    ;
+
+    [Test]
+    public void AnUnwritableTarget_IsReportedNotThrown() {
+      // a directory can never be opened as a file
+      var target = this._directory.File("subdirectory");
+      Directory.CreateDirectory(target);
+
+      using (var bitmap = TestBitmaps.Create())
+        Assert.That(CLI.SaveHelper(target, bitmap), Is.EqualTo(CLIExitCode.ExceptionDuringImageWrite));
+    }
+
+    [Test]
+    public void SavingTwiceToTheSamePath_Succeeds() {
+      var file = this._directory.File("out.png");
+
+      using (var bitmap = TestBitmaps.Create(5, 5))
+        CLI.SaveHelper(file, bitmap);
+
+      using (var bitmap = TestBitmaps.Create(10, 10))
+        Assert.That(CLI.SaveHelper(file, bitmap), Is.EqualTo(CLIExitCode.OK));
+
+      Assert.That(TestBitmaps.SizeOf(file).Width, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void ASuccessfulSave_LeavesOnlyTheTargetBehind() {
+      var file = this._directory.File("out.png");
+
+      using (var bitmap = TestBitmaps.Create())
+        CLI.SaveHelper(file, bitmap);
+
+      Assert.That(Directory.GetFiles(this._directory.Path), Is.EqualTo(new[] { file }), "the atomic-save temp file must be gone");
+    }
+  }
+}

--- a/Tests/ImageResizer.Tests/ScriptActionTests.cs
+++ b/Tests/ImageResizer.Tests/ScriptActionTests.cs
@@ -1,0 +1,329 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using System.Drawing.Extensions.ColorProcessing.Resizing;
+using System.IO;
+using System.Linq;
+
+using Classes;
+using Classes.ScriptActions;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Covers the individual script actions - what each one reads, what it writes and how it fails.
+  /// </summary>
+  [TestFixture]
+  public class ScriptActionTests {
+
+    private TemporaryDirectory _directory;
+
+    [SetUp]
+    public void SetUp() => this._directory = new TemporaryDirectory();
+
+    [TearDown]
+    public void TearDown() => this._directory.Dispose();
+
+    #region /load
+
+    [Test]
+    public void LoadFileCommand_ReadsTheFileIntoTheSourceSlot() {
+      var file = TestBitmaps.WriteTo(this._directory.File("in.png"), 23, 17);
+      var command = new LoadFileCommand(file);
+
+      Assert.That(command.Execute(), Is.True);
+
+      Assert.That(command.SourceImage.Width, Is.EqualTo(23));
+      Assert.That(command.SourceImage.Height, Is.EqualTo(17));
+    }
+
+    [Test]
+    public void LoadFileCommand_KeepsTheFileName() {
+      var command = new LoadFileCommand("whatever.png");
+
+      Assert.That(command.FileName, Is.EqualTo("whatever.png"));
+    }
+
+    [Test]
+    public void LoadFileCommand_ReleasesTheFileHandle() {
+      var file = TestBitmaps.WriteTo(this._directory.File("in.png"));
+      new LoadFileCommand(file).Execute();
+
+      Assert.That(() => File.Delete(file), Throws.Nothing, "the loader must not keep the file open");
+    }
+
+    [Test]
+    public void LoadFileCommand_ReportsNoPoolKeyWithoutAPool() {
+      var file = TestBitmaps.WriteTo(this._directory.File("in.png"));
+      var command = new LoadFileCommand(file);
+
+      command.Execute();
+
+      Assert.That(command.PoolSourceKey, Is.Null);
+    }
+
+    [Test]
+    public void LoadFileCommand_OnAMissingFile_Throws() {
+      var command = new LoadFileCommand(this._directory.File("nope.png"));
+
+      Assert.That(() => command.Execute(), Throws.InstanceOf<FileNotFoundException>());
+    }
+
+    [Test]
+    public void LoadFileCommand_OnAFileThatIsNotAnImage_Throws() {
+      var file = this._directory.File("garbage.png");
+      File.WriteAllText(file, "this is not a PNG");
+      var command = new LoadFileCommand(file);
+
+      Assert.That(() => command.Execute(), Throws.InstanceOf<OutOfMemoryException>().Or.InstanceOf<ArgumentException>());
+    }
+
+    [TestCase(".png")]
+    [TestCase(".bmp")]
+    [TestCase(".gif")]
+    [TestCase(".jpg")]
+    [TestCase(".tif")]
+    public void LoadFileCommand_ReadsEveryFormatTheSaverWrites(string extension) {
+      var file = TestBitmaps.WriteTo(this._directory.File("in" + extension), 8, 8);
+      var command = new LoadFileCommand(file);
+
+      Assert.That(command.Execute(), Is.True);
+      Assert.That(command.SourceImage.Width, Is.EqualTo(8));
+    }
+
+    #endregion
+
+    #region /save
+
+    [Test]
+    public void SaveFileCommand_WritesTheTargetToDisk() {
+      var file = this._directory.File("out.png");
+      var command = new SaveFileCommand(file) { TargetImage = TestBitmaps.Create(9, 11) };
+
+      Assert.That(command.Execute(), Is.True);
+
+      Assert.That(TestBitmaps.SizeOf(file), Is.EqualTo(new Size(9, 11)));
+    }
+
+    [Test]
+    public void SaveFileCommand_WithNothingInTheTarget_Throws() {
+      var command = new SaveFileCommand(this._directory.File("out.png"));
+
+      Assert.That(() => command.Execute(), Throws.InstanceOf<NullReferenceException>());
+    }
+
+    [Test]
+    public void SaveFileCommand_DoesNotDisposeTheTargetItWrote() {
+      var command = new SaveFileCommand(this._directory.File("out.png")) { TargetImage = TestBitmaps.Create() };
+
+      command.Execute();
+
+      Assert.That(() => command.TargetImage.Width, Throws.Nothing, "the engine still owns it");
+    }
+
+    [Test]
+    public void SaveFileCommand_OverwritesAnExistingFile() {
+      var file = TestBitmaps.WriteTo(this._directory.File("out.png"), 4, 4);
+      var command = new SaveFileCommand(file) { TargetImage = TestBitmaps.Create(12, 12) };
+
+      command.Execute();
+
+      Assert.That(TestBitmaps.SizeOf(file), Is.EqualTo(new Size(12, 12)));
+    }
+
+    [Test]
+    public void SaveFileCommand_LeavesNoTemporaryFilesBehind() {
+      var file = this._directory.File("out.png");
+      new SaveFileCommand(file) { TargetImage = TestBitmaps.Create() }.Execute();
+
+      Assert.That(Directory.GetFiles(this._directory.Path), Is.EqualTo(new[] { file }));
+    }
+
+    #endregion
+
+    #region transfer actions
+
+    [Test]
+    public void NullTransformCommand_CopiesTheSourceIntoTheTarget() {
+      var source = TestBitmaps.Create(7, 5);
+      var command = new NullTransformCommand { SourceImage = source };
+
+      command.Execute();
+
+      Assert.That(command.TargetImage, Is.Not.SameAs(source), "an alias would make the two slots share a lifetime");
+      Assert.That(command.TargetImage.Size, Is.EqualTo(new Size(7, 5)));
+    }
+
+    [Test]
+    public void NullTransformCommand_WithoutASource_ProducesNoTarget() {
+      var command = new NullTransformCommand();
+
+      command.Execute();
+
+      Assert.That(command.TargetImage, Is.Null);
+    }
+
+    [Test]
+    public void TargetToSourceCommand_MovesTheTargetIntoTheSource() {
+      var target = TestBitmaps.Create(6, 6);
+      var command = new TargetToSourceCommand { TargetImage = target };
+
+      command.Execute();
+
+      Assert.That(command.SourceImage.Size, Is.EqualTo(new Size(6, 6)));
+      Assert.That(command.SourceImage, Is.Not.SameAs(target));
+      Assert.That(command.TargetImage, Is.Null);
+    }
+
+    [Test]
+    public void TargetToSourceCommand_WithoutATarget_ClearsTheSource() {
+      var command = new TargetToSourceCommand { SourceImage = TestBitmaps.Create() };
+
+      command.Execute();
+
+      Assert.That(command.SourceImage, Is.Null);
+    }
+
+    #endregion
+
+    #region /resize
+
+    /// <summary>
+    /// Builds a resize command the way the parser would, against a resampler that honours
+    /// explicit width and height.
+    /// </summary>
+    private static ResizeCommand _Resize(ushort width, ushort height, ushort percentage, bool maintainAspect)
+      => new ResizeCommand(
+        false,
+        SupportedManipulators.MANIPULATORS.First(m => m.Key == "Resampler: Bicubic").Value,
+        width, height, percentage, maintainAspect,
+        OutOfBoundsMode.ConstantExtension, OutOfBoundsMode.ConstantExtension,
+        1, true, true, 1f
+      )
+    ;
+
+    [Test]
+    public void Resize_ToExplicitDimensions_HitsThemExactly() {
+      var command = _Resize(40, 30, 0, false);
+      command.SourceImage = TestBitmaps.Create(20, 20);
+
+      command.Execute();
+
+      Assert.That(command.TargetImage.Size, Is.EqualTo(new Size(40, 30)));
+    }
+
+    [TestCase(100, 20, 20)]
+    [TestCase(200, 40, 40)]
+    [TestCase(50, 10, 10)]
+    [TestCase(325, 65, 65)]
+    public void Resize_ByPercentage_ScalesBothAxes(int percentage, int expectedWidth, int expectedHeight) {
+      var command = _Resize(0, 0, (ushort)percentage, true);
+      command.SourceImage = TestBitmaps.Create(20, 20);
+
+      command.Execute();
+
+      Assert.That(command.TargetImage.Size, Is.EqualTo(new Size(expectedWidth, expectedHeight)));
+    }
+
+    [Test]
+    public void Resize_WidthOnly_DerivesTheHeightFromTheAspectRatio() {
+      var command = _Resize(60, 0, 0, true);
+      command.SourceImage = TestBitmaps.Create(30, 20);
+
+      command.Execute();
+
+      Assert.That(command.TargetImage.Size, Is.EqualTo(new Size(60, 40)));
+    }
+
+    [Test]
+    public void Resize_HeightOnly_DerivesTheWidthFromTheAspectRatio() {
+      var command = _Resize(0, 40, 0, true);
+      command.SourceImage = TestBitmaps.Create(30, 20);
+
+      command.Execute();
+
+      Assert.That(command.TargetImage.Size, Is.EqualTo(new Size(60, 40)));
+    }
+
+    [Test]
+    public void Resize_ToASinglePixel_Works() {
+      var command = _Resize(1, 1, 0, false);
+      command.SourceImage = TestBitmaps.Create(32, 32);
+
+      command.Execute();
+
+      Assert.That(command.TargetImage.Size, Is.EqualTo(new Size(1, 1)));
+    }
+
+    [Test]
+    public void Resize_OfASinglePixelSource_Works() {
+      var command = _Resize(8, 8, 0, false);
+      command.SourceImage = TestBitmaps.Create(1, 1);
+
+      command.Execute();
+
+      Assert.That(command.TargetImage.Size, Is.EqualTo(new Size(8, 8)));
+    }
+
+    [Test]
+    public void Resize_KeepsItsParameters() {
+      var command = new ResizeCommand(
+        false,
+        SupportedManipulators.MANIPULATORS.First(m => m.Key == "Resampler: Bicubic").Value,
+        1, 2, 3, true,
+        OutOfBoundsMode.WrapAround, OutOfBoundsMode.HalfSampleSymmetric,
+        7, false, false, 2.5f
+      );
+
+      Assert.That(command.Width, Is.EqualTo(1));
+      Assert.That(command.Height, Is.EqualTo(2));
+      Assert.That(command.Percentage, Is.EqualTo(3));
+      Assert.That(command.MaintainAspect, Is.True);
+      Assert.That(command.HorizontalBph, Is.EqualTo(OutOfBoundsMode.WrapAround));
+      Assert.That(command.VerticalBph, Is.EqualTo(OutOfBoundsMode.HalfSampleSymmetric));
+      Assert.That(command.Count, Is.EqualTo(7));
+      Assert.That(command.UseThresholds, Is.False);
+      Assert.That(command.UseCenteredGrid, Is.False);
+      Assert.That(command.Radius, Is.EqualTo(2.5f));
+    }
+
+    [Test]
+    public void FixedFactorUpscaler_IgnoresRequestedDimensions() {
+      var command = new ResizeCommand(
+        false,
+        SupportedManipulators.MANIPULATORS.First(m => m.Key == "Upscaler: HQ 2x").Value,
+        999, 999, 0, false,
+        OutOfBoundsMode.ConstantExtension, OutOfBoundsMode.ConstantExtension,
+        1, true, true, 1f
+      );
+      command.SourceImage = TestBitmaps.Create(16, 16);
+
+      command.Execute();
+
+      Assert.That(command.TargetImage.Size, Is.EqualTo(new Size(32, 32)), "the factor is the algorithm's, not the caller's");
+    }
+
+    #endregion
+
+  }
+}

--- a/Tests/ImageResizer.Tests/ScriptEngineTests.cs
+++ b/Tests/ImageResizer.Tests/ScriptEngineTests.cs
@@ -1,0 +1,376 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+using Classes;
+using Classes.ScriptActions;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Covers <see cref="ScriptEngine"/>: action bookkeeping, the source/target promotion rules and
+  /// the ownership contract its setters implement.
+  /// </summary>
+  [TestFixture]
+  public class ScriptEngineTests {
+
+    #region helpers
+
+    /// <summary>A script action whose behaviour each test dictates.</summary>
+    private sealed class StubAction : IScriptAction {
+      public bool ChangesSourceImage { get; set; }
+      public bool ChangesTargetImage { get; set; }
+      public bool ProvidesNewGdiSource => false;
+      public string PoolSourceKey => null;
+      public Bitmap GdiSource => null;
+      public Bitmap SourceImage { get; set; }
+      public Bitmap TargetImage { get; set; }
+
+      /// <summary>What the action assigns to the slots it claims to change.</summary>
+      public Func<Bitmap> ProduceSource { get; set; }
+      public Func<Bitmap> ProduceTarget { get; set; }
+
+      public int Executions { get; private set; }
+
+      /// <summary>The source the engine handed in, recorded at execution time.</summary>
+      public Bitmap ObservedSource { get; private set; }
+      public Bitmap ObservedTarget { get; private set; }
+
+      public bool Execute() {
+        ++this.Executions;
+        this.ObservedSource = this.SourceImage;
+        this.ObservedTarget = this.TargetImage;
+
+        if (this.ChangesSourceImage && this.ProduceSource != null)
+          this.SourceImage = this.ProduceSource();
+
+        if (this.ChangesTargetImage && this.ProduceTarget != null)
+          this.TargetImage = this.ProduceTarget();
+
+        return true;
+      }
+    }
+
+    /// <summary>Reports whether a bitmap has already been disposed.</summary>
+    private static bool _IsDisposed(Bitmap bitmap) {
+      try {
+        var unused = bitmap.Width;
+        return false;
+      } catch (ArgumentException) {
+        return true;
+      } catch (ObjectDisposedException) {
+        return true;
+      }
+    }
+
+    private static StubAction _SourceProducer(Bitmap bitmap)
+      => new StubAction { ChangesSourceImage = true, ProduceSource = () => bitmap }
+    ;
+
+    #endregion
+
+    #region action list
+
+    [Test]
+    public void NewEngine_HasNoActionsAndNoImages() {
+      var engine = new ScriptEngine();
+
+      Assert.That(engine.Actions, Is.Empty);
+      Assert.That(engine.SourceImage, Is.Null);
+      Assert.That(engine.TargetImage, Is.Null);
+    }
+
+    [Test]
+    public void AddWithoutExecution_QueuesButDoesNotRun() {
+      var engine = new ScriptEngine();
+      var action = new StubAction();
+
+      engine.AddWithoutExecution(action);
+
+      Assert.That(engine.Actions.Count(), Is.EqualTo(1));
+      Assert.That(action.Executions, Is.Zero);
+    }
+
+    [Test]
+    public void ExecuteAction_RunsAndRecords() {
+      var engine = new ScriptEngine();
+      var action = new StubAction();
+
+      engine.ExecuteAction(action);
+
+      Assert.That(action.Executions, Is.EqualTo(1));
+      Assert.That(engine.Actions.Single(), Is.SameAs(action));
+    }
+
+    [Test]
+    public void RepeatActions_RunsEveryQueuedActionInOrder() {
+      var engine = new ScriptEngine();
+      var order = new List<int>();
+      for (var i = 0; i < 3; ++i) {
+        var index = i;
+        var action = new StubAction { ChangesTargetImage = true, ProduceTarget = () => { order.Add(index); return null; } };
+        engine.AddWithoutExecution(action);
+      }
+
+      engine.RepeatActions();
+
+      Assert.That(order, Is.EqualTo(new[] { 0, 1, 2 }));
+    }
+
+    [Test]
+    public void RepeatActions_DoesNotGrowTheActionList() {
+      var engine = new ScriptEngine();
+      engine.AddWithoutExecution(new StubAction());
+
+      engine.RepeatActions();
+
+      Assert.That(engine.Actions.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void RepeatActions_CallsThePreAndPostHooksAroundEachAction() {
+      var engine = new ScriptEngine();
+      var action = new StubAction();
+      engine.AddWithoutExecution(action);
+      var log = new List<string>();
+
+      engine.RepeatActions((e, c) => log.Add("pre"), (e, c) => log.Add("post"));
+
+      Assert.That(log, Is.EqualTo(new[] { "pre", "post" }));
+    }
+
+    [Test]
+    public void RepeatActions_WithoutHooks_Works()
+      => Assert.That(() => new ScriptEngine().RepeatActions(), Throws.Nothing)
+    ;
+
+    [Test]
+    public void Clear_EmptiesTheActionList() {
+      var engine = new ScriptEngine();
+      engine.AddWithoutExecution(new StubAction());
+
+      engine.Clear();
+
+      Assert.That(engine.Actions, Is.Empty);
+    }
+
+    [Test]
+    public void Actions_IsASnapshotTheCallerCannotMutate() {
+      var engine = new ScriptEngine();
+      engine.AddWithoutExecution(new StubAction());
+
+      Assert.That(engine.Actions, Is.Not.InstanceOf<ICollection<IScriptAction>>().And.Not.InstanceOf<IList<IScriptAction>>());
+    }
+
+    #endregion
+
+    #region image promotion
+
+    [Test]
+    public void ActionThatChangesTheSource_PromotesItIntoTheEngine() {
+      var engine = new ScriptEngine();
+      var produced = TestBitmaps.Create();
+
+      engine.ExecuteAction(_SourceProducer(produced));
+
+      Assert.That(engine.SourceImage, Is.SameAs(produced));
+      Assert.That(engine.IsSourceImageChanged, Is.True);
+    }
+
+    [Test]
+    public void ActionThatChangesTheTarget_PromotesItIntoTheEngine() {
+      var engine = new ScriptEngine();
+      var produced = TestBitmaps.Create();
+
+      engine.ExecuteAction(new StubAction { ChangesTargetImage = true, ProduceTarget = () => produced });
+
+      Assert.That(engine.TargetImage, Is.SameAs(produced));
+      Assert.That(engine.IsTargetImageChanged, Is.True);
+    }
+
+    [Test]
+    public void ActionThatChangesNothing_LeavesTheSlotsAlone() {
+      var engine = new ScriptEngine();
+      var source = TestBitmaps.Create();
+      engine.ExecuteAction(_SourceProducer(source));
+
+      engine.ExecuteAction(new StubAction());
+
+      Assert.That(engine.SourceImage, Is.SameAs(source));
+      Assert.That(engine.IsSourceImageChanged, Is.False);
+      Assert.That(engine.IsTargetImageChanged, Is.False);
+    }
+
+    [Test]
+    public void EachAction_SeesTheCurrentSlotContents() {
+      var engine = new ScriptEngine();
+      var source = TestBitmaps.Create();
+      engine.ExecuteAction(_SourceProducer(source));
+      var observer = new StubAction();
+
+      engine.ExecuteAction(observer);
+
+      Assert.That(observer.ObservedSource, Is.SameAs(source));
+    }
+
+    [Test]
+    public void GdiAliases_TrackTheSlots() {
+      var engine = new ScriptEngine();
+      var source = TestBitmaps.Create();
+
+      engine.ExecuteAction(_SourceProducer(source));
+
+      Assert.That(engine.GdiSource, Is.SameAs(engine.SourceImage));
+      Assert.That(engine.GdiTarget, Is.SameAs(engine.TargetImage));
+    }
+
+    #endregion
+
+    #region ownership
+
+    [Test]
+    public void ReplacingTheSource_DisposesTheOneItReplaces() {
+      var engine = new ScriptEngine();
+      var first = TestBitmaps.Create();
+      engine.ExecuteAction(_SourceProducer(first));
+
+      engine.ExecuteAction(_SourceProducer(TestBitmaps.Create()));
+
+      Assert.That(_IsDisposed(first), Is.True);
+    }
+
+    [Test]
+    public void ReplacingTheSourceWithItself_DoesNotDisposeIt() {
+      var engine = new ScriptEngine();
+      var bitmap = TestBitmaps.Create();
+      engine.ExecuteAction(_SourceProducer(bitmap));
+
+      engine.ExecuteAction(_SourceProducer(bitmap));
+
+      Assert.That(_IsDisposed(bitmap), Is.False);
+      Assert.That(engine.SourceImage, Is.SameAs(bitmap));
+    }
+
+    [Test]
+    public void ReplacingTheTarget_DisposesTheOneItReplaces() {
+      var engine = new ScriptEngine();
+      var first = TestBitmaps.Create();
+      engine.ExecuteAction(new StubAction { ChangesTargetImage = true, ProduceTarget = () => first });
+
+      engine.ExecuteAction(new StubAction { ChangesTargetImage = true, ProduceTarget = () => TestBitmaps.Create() });
+
+      Assert.That(_IsDisposed(first), Is.True);
+    }
+
+    [Test]
+    public void PoolManagedSource_IsNotDisposedWhenReplaced() {
+      var engine = new ScriptEngine();
+      var pooled = TestBitmaps.Create();
+      engine.SetSourceImageNonOwning(pooled, "key");
+
+      engine.ExecuteAction(_SourceProducer(TestBitmaps.Create()));
+
+      Assert.That(_IsDisposed(pooled), Is.False, "the pool owns it; disposing would corrupt every later checkout");
+    }
+
+    [Test]
+    public void PoolManagedSource_ExposesItsKey() {
+      var engine = new ScriptEngine();
+
+      engine.SetSourceImageNonOwning(TestBitmaps.Create(), "some/file.png");
+
+      Assert.That(engine.CurrentSourceKey, Is.EqualTo("some/file.png"));
+    }
+
+    [Test]
+    public void EngineOwnedSource_HasNoPoolKey() {
+      var engine = new ScriptEngine();
+
+      engine.ExecuteAction(_SourceProducer(TestBitmaps.Create()));
+
+      Assert.That(engine.CurrentSourceKey, Is.Null);
+    }
+
+    [Test]
+    public void PromotingAnEngineOwnedSource_ClearsAPreviousPoolKey() {
+      var engine = new ScriptEngine();
+      engine.SetSourceImageNonOwning(TestBitmaps.Create(), "key");
+
+      engine.ExecuteAction(_SourceProducer(TestBitmaps.Create()));
+
+      Assert.That(engine.CurrentSourceKey, Is.Null);
+    }
+
+    #endregion
+
+    #region revert
+
+    [Test]
+    public void RevertToLastSource_DropsTrailingActionsThatLeftTheSourceAlone() {
+      var engine = new ScriptEngine();
+      var sourceChanging = _SourceProducer(TestBitmaps.Create());
+      engine.AddWithoutExecution(sourceChanging);
+      engine.AddWithoutExecution(new StubAction { ChangesTargetImage = true });
+      engine.AddWithoutExecution(new StubAction { ChangesTargetImage = true });
+
+      engine.RevertToLastSource();
+
+      Assert.That(engine.Actions.Single(), Is.SameAs(sourceChanging));
+    }
+
+    [Test]
+    public void RevertToLastSource_KeepsAListThatEndsOnASourceChange() {
+      var engine = new ScriptEngine();
+      engine.AddWithoutExecution(new StubAction { ChangesTargetImage = true });
+      engine.AddWithoutExecution(_SourceProducer(TestBitmaps.Create()));
+
+      engine.RevertToLastSource();
+
+      Assert.That(engine.Actions.Count(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void RevertToLastSource_OnAnEmptyList_DoesNothing() {
+      var engine = new ScriptEngine();
+
+      Assert.That(() => engine.RevertToLastSource(), Throws.Nothing);
+      Assert.That(engine.Actions, Is.Empty);
+    }
+
+    [Test]
+    public void RevertToLastSource_WithNoSourceChangeAtAll_EmptiesTheList() {
+      var engine = new ScriptEngine();
+      engine.AddWithoutExecution(new StubAction { ChangesTargetImage = true });
+      engine.AddWithoutExecution(new StubAction { ChangesTargetImage = true });
+
+      engine.RevertToLastSource();
+
+      Assert.That(engine.Actions, Is.Empty);
+    }
+
+    #endregion
+
+  }
+}

--- a/Tests/ImageResizer.Tests/SupportedManipulatorsTests.cs
+++ b/Tests/ImageResizer.Tests/SupportedManipulatorsTests.cs
@@ -1,0 +1,181 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Linq;
+
+using Classes;
+using Classes.ImageManipulators;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Invariants of the manipulator registry. These are the assumptions the parser, the help text
+  /// and the GUI dropdown all rest on; a new algorithm that breaks one of them breaks all three.
+  /// </summary>
+  [TestFixture]
+  public class SupportedManipulatorsTests {
+
+    /// <summary>Categories the registration code is allowed to produce.</summary>
+    private static readonly string[] _KNOWN_CATEGORIES = {
+      "Upscaler", "Downscaler", "Resampler", "Downsampler", "Filter", "Plane",
+    };
+
+    [Test]
+    public void TheRegistryIsNotEmpty()
+      => Assert.That(SupportedManipulators.MANIPULATORS, Is.Not.Empty)
+    ;
+
+    [Test]
+    public void EveryEntryHasAManipulator() {
+      var empty = SupportedManipulators.MANIPULATORS.Where(pair => pair.Value == null).Select(pair => pair.Key);
+
+      Assert.That(empty, Is.Empty);
+    }
+
+    [Test]
+    public void EveryKeyIsNonEmpty() {
+      var blank = SupportedManipulators.MANIPULATORS.Where(pair => string.IsNullOrWhiteSpace(pair.Key));
+
+      Assert.That(blank.Count(), Is.Zero);
+    }
+
+    [Test]
+    public void KeysAreUniqueIgnoringCase() {
+      var duplicates = SupportedManipulators.MANIPULATORS
+        .GroupBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+        .Where(group => group.Count() > 1)
+        .Select(group => group.Key)
+        ;
+
+      Assert.That(duplicates, Is.Empty, "a duplicate key makes one of the two unreachable by name");
+    }
+
+    [Test]
+    public void EveryKeyCarriesACategory() {
+      var uncategorised = SupportedManipulators.MANIPULATORS
+        .Where(pair => pair.Key.IndexOf(ScriptSerializer.CATEGORY_SEPARATOR, StringComparison.Ordinal) < 0)
+        .Select(pair => pair.Key)
+        ;
+
+      Assert.That(uncategorised, Is.Empty);
+    }
+
+    [Test]
+    public void EveryCategoryIsOneOfTheDocumentedOnes() {
+      var unexpected = SupportedManipulators.MANIPULATORS
+        .Select(pair => pair.Key.Substring(0, pair.Key.IndexOf(ScriptSerializer.CATEGORY_SEPARATOR, StringComparison.Ordinal)))
+        .Distinct()
+        .Where(category => !_KNOWN_CATEGORIES.Contains(category))
+        ;
+
+      Assert.That(unexpected, Is.Empty, "README and AGENTS.md list the categories - keep them in sync");
+    }
+
+    [Test]
+    public void EveryEntryIsReachableByItsFullName() {
+      var unreachable = SupportedManipulators.MANIPULATORS
+        .Where(pair => !ReferenceEquals(ScriptSerializer.FindManipulator(SupportedManipulators.MANIPULATORS, pair.Key, out _), pair.Value))
+        .Select(pair => pair.Key)
+        ;
+
+      Assert.That(unreachable, Is.Empty);
+    }
+
+    [Test]
+    public void TheRegistryIsSortedByKey() {
+      var keys = SupportedManipulators.MANIPULATORS.Select(pair => pair.Key).ToArray();
+
+      Assert.That(keys, Is.Ordered.Using((System.Collections.IComparer)StringComparer.OrdinalIgnoreCase), "the help text and the dropdown present it as-is");
+    }
+
+    [Test]
+    public void EveryEntryHasADescription() {
+      var undescribed = SupportedManipulators.MANIPULATORS
+        .Where(pair => string.IsNullOrWhiteSpace(pair.Value.Description))
+        .Select(pair => pair.Key)
+        ;
+
+      Assert.That(undescribed, Is.Empty);
+    }
+
+    [Test]
+    public void EveryEntryExposesAParameterList() {
+      var missing = SupportedManipulators.MANIPULATORS
+        .Where(pair => pair.Value.Parameters == null)
+        .Select(pair => pair.Key)
+        ;
+
+      Assert.That(missing, Is.Empty, "callers enumerate it unconditionally");
+    }
+
+    [Test]
+    public void UpscalersChangeResolution() {
+      var offenders = SupportedManipulators.MANIPULATORS
+        .Where(pair => pair.Key.StartsWith("Upscaler" + ScriptSerializer.CATEGORY_SEPARATOR, StringComparison.Ordinal))
+        .Where(pair => !pair.Value.ChangesResolution)
+        .Select(pair => pair.Key)
+        ;
+
+      Assert.That(offenders, Is.Empty);
+    }
+
+    [Test]
+    public void FiltersDoNotChangeResolution() {
+      var offenders = SupportedManipulators.MANIPULATORS
+        .Where(pair => pair.Key.StartsWith("Filter" + ScriptSerializer.CATEGORY_SEPARATOR, StringComparison.Ordinal))
+        .Where(pair => pair.Value.ChangesResolution)
+        .Select(pair => pair.Key)
+        ;
+
+      Assert.That(offenders, Is.Empty);
+    }
+
+    [Test]
+    public void ResamplersAcceptBothDimensions() {
+      var offenders = SupportedManipulators.MANIPULATORS
+        .Where(pair => pair.Value is BitmapResamplerAdapter)
+        .Where(pair => !(pair.Value.SupportsWidth && pair.Value.SupportsHeight))
+        .Select(pair => pair.Key)
+        ;
+
+      Assert.That(offenders, Is.Empty);
+    }
+
+    [Test]
+    public void NonParametricManipulators_ReturnThemselvesFromCreateWith() {
+      var manipulator = SupportedManipulators.MANIPULATORS.First(pair => pair.Value.Parameters.Count == 0).Value;
+
+      Assert.That(manipulator.CreateWith(null), Is.SameAs(manipulator), "callers chain CreateWith unconditionally");
+    }
+
+    [Test]
+    public void TheWellKnownAlgorithmsAreStillRegistered() {
+      var keys = SupportedManipulators.MANIPULATORS.Select(pair => pair.Key).ToArray();
+
+      Assert.That(keys, Does.Contain("Upscaler: HQ 2x"));
+      Assert.That(keys, Does.Contain("Upscaler: XBR 3x"));
+      Assert.That(keys, Does.Contain("Upscaler: Scale 2x"));
+      Assert.That(keys, Does.Contain("Upscaler: Eagle"));
+      Assert.That(keys, Does.Contain("Resampler: Bicubic"));
+    }
+  }
+}

--- a/Tests/ImageResizer.Tests/TestBitmaps.cs
+++ b/Tests/ImageResizer.Tests/TestBitmaps.cs
@@ -1,0 +1,130 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Throwaway bitmaps and files for tests. Everything lands under a per-run temp directory that
+  /// <see cref="TemporaryDirectory"/> removes again, so a failing test cannot leak into the next.
+  /// </summary>
+  internal static class TestBitmaps {
+
+    /// <summary>
+    /// Creates a bitmap with a deterministic, non-uniform pattern - a flat fill would let a
+    /// broken scaler look correct.
+    /// </summary>
+    /// <param name="width">The width.</param>
+    /// <param name="height">The height.</param>
+    /// <returns>The bitmap; the caller owns it.</returns>
+    public static Bitmap Create(int width = 16, int height = 16) {
+      var result = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+      for (var y = 0; y < height; ++y)
+      for (var x = 0; x < width; ++x)
+        result.SetPixel(x, y, Color.FromArgb(255, x * 255 / Math.Max(1, width - 1), y * 255 / Math.Max(1, height - 1), (x ^ y) & 0xff));
+
+      return result;
+    }
+
+    /// <summary>
+    /// Writes a bitmap to disk.
+    /// </summary>
+    /// <param name="path">The target path; its extension picks the format.</param>
+    /// <param name="width">The width.</param>
+    /// <param name="height">The height.</param>
+    /// <returns><paramref name="path"/>.</returns>
+    public static string WriteTo(string path, int width = 16, int height = 16) {
+      using (var bitmap = Create(width, height))
+        bitmap.Save(path, FormatFor(path));
+
+      return path;
+    }
+
+    /// <summary>
+    /// Maps a file extension to the format <see cref="Image.Save(string, ImageFormat)"/> needs.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <returns>The format.</returns>
+    public static ImageFormat FormatFor(string path) {
+      switch (Path.GetExtension(path)?.ToUpperInvariant()) {
+        case ".BMP": return ImageFormat.Bmp;
+        case ".GIF": return ImageFormat.Gif;
+        case ".JPG":
+        case ".JPEG": return ImageFormat.Jpeg;
+        case ".TIF":
+        case ".TIFF": return ImageFormat.Tiff;
+        default: return ImageFormat.Png;
+      }
+    }
+
+    /// <summary>
+    /// Reads back the dimensions of an image file without keeping it open.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <returns>The size.</returns>
+    public static Size SizeOf(string path) {
+      using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+      using (var image = Image.FromStream(stream, false, false))
+        return image.Size;
+    }
+
+    /// <summary>
+    /// Reads back the container format of an image file without keeping it open.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <returns>The raw format.</returns>
+    public static ImageFormat RawFormatOf(string path) {
+      using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+      using (var image = Image.FromStream(stream, false, false))
+        return image.RawFormat;
+    }
+  }
+
+  /// <summary>
+  /// A scratch directory that deletes itself on <see cref="Dispose"/>.
+  /// </summary>
+  internal sealed class TemporaryDirectory : IDisposable {
+
+    public string Path { get; }
+
+    public TemporaryDirectory() {
+      this.Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ImageResizer.Tests", Guid.NewGuid().ToString("N"));
+      Directory.CreateDirectory(this.Path);
+    }
+
+    /// <summary>
+    /// Combines a file name with this directory.
+    /// </summary>
+    /// <param name="fileName">The file name.</param>
+    /// <returns>The full path.</returns>
+    public string File(string fileName) => System.IO.Path.Combine(this.Path, fileName);
+
+    public void Dispose() {
+      try {
+        Directory.Delete(this.Path, true);
+      } catch (IOException) {
+        // a leaked handle must not turn into a test failure
+      }
+    }
+  }
+}


### PR DESCRIPTION
Broadens the suite from the parser-only tests in #35 to the rest of the application. **228 tests total**, up from 81.

Stacked on #35 — review that first; this PR retargets to `main` once it merges.

## Unit coverage

| Area | What it pins |
|---|---|
| `ScriptEngine` | action bookkeeping, source/target promotion, the revert rule, and the ownership contract its setters implement — including that a pool-managed source is never disposed on replace, the invariant that keeps `CheckoutClone` valid |
| Script actions | what each reads and writes, that the loader releases its file handle, that the saver leaves no atomic-save temp file behind, and the resize dimension maths for every dimension form |
| `CLI.SaveHelper` | extension-to-encoder mapping including the PNG fallback, and that an unwritable target is *reported* as an exit code rather than thrown |
| `Config` | round trip of every setting, XML special characters, and the input it must tolerate — missing file, foreign root, unknown elements, unparseable enums |
| `SupportedManipulators` | the invariants the parser, help text and GUI dropdown all rest on: unique keys, a known category on every one, sorted order, every entry resolvable by its own name |

## End-to-end coverage

48 cases that run the real `ImageResizer.exe` with real command lines and check what it wrote and what it exited with. **This is the layer #33 broke** — every unit underneath was fine, the assembled program was not.

Covers the exact command line from that issue, every dimension form, filter chaining, multi-file and multi-save runs, `/script` files, all help switches, and one case per failure exit code.

Each run is capped at a 60 s timeout with both pipes drained before the wait, so a hung or chatty child cannot stall the suite.

## Scope

No pixel comparison — these assert dimensions, container format, exit codes and diagnostics. Visual regressions need reference images and are a separate concern, as `AGENTS.md` notes.

## Verification

`dotnet test ImageResizer.slnx -c Release` → 228/228 green in ~7 s.