### PR TITLE
# progress reports on STDOUT corrupted every piped image

### DIFF
--- a/ImageResizer/Classes/CLI.cs
+++ b/ImageResizer/Classes/CLI.cs
@@ -45,6 +45,16 @@ namespace Classes {
     private static readonly string[] _HELP_ARGUMENTS = { "/?", "-?", "--?", "/h", "-h", "/help", "--help" };
 
     /// <summary>
+    /// Where progress reports and errors go.
+    /// <para>
+    /// Never standard output: <see cref="ScriptActions.SaveStdOutCommand"/> writes a PNG there, and
+    /// anything else on that stream corrupts the image for whatever is on the other end of the
+    /// pipe. Standard output carries image data and nothing else.
+    /// </para>
+    /// </summary>
+    private static TextWriter _Diagnostics => Console.Error;
+
+    /// <summary>
     /// Parses the command line arguments.
     /// </summary>
     /// <param name="arguments">The arguments.</param>
@@ -54,22 +64,23 @@ namespace Classes {
 
       // only the leading argument, so a file that happens to be named like a switch stays a file
       if (_HELP_ARGUMENTS.Contains(arguments[0], StringComparer.OrdinalIgnoreCase)) {
-        _ShowHelp();
+        // help that was asked for is the output of the run, so it goes to standard output
+        _ShowHelp(Console.Out);
         return CLIExitCode.OK;
       }
 
       var engine = new ScriptEngine();
       var line = string.Join(" ", arguments.Select(a => string.Format(@"""{0}""", a)));
-      Console.WriteLine("Executing the following script:");
-      Console.WriteLine(line);
-      Console.WriteLine();
+      _Diagnostics.WriteLine("Executing the following script:");
+      _Diagnostics.WriteLine(line);
+      _Diagnostics.WriteLine();
 
       // load script from command line parameters
       try {
         ScriptSerializer.LoadFromString(engine, line);
       } catch (ScriptSerializerException e) {
         _ShowError(e);
-        _ShowHelp();
+        _ShowHelp(_Diagnostics);
         return e.ErrorType;
       }
 
@@ -77,7 +88,7 @@ namespace Classes {
       try {
         engine.RepeatActions(_PreAction, _PostAction);
       } catch (Exception e) {
-        Console.WriteLine(e.Message);
+        _Diagnostics.WriteLine(e.Message);
         return CLIExitCode.RuntimeError;
       }
 
@@ -87,22 +98,22 @@ namespace Classes {
     private static void _PreAction(ScriptEngine engine, IScriptAction command) {
       switch (command) {
         case LoadFileCommand loadCommand:
-          Console.WriteLine("Loading from file " + loadCommand.FileName);
+          _Diagnostics.WriteLine("Loading from file " + loadCommand.FileName);
           return;
         case SaveFileCommand saveCommand:
-          Console.WriteLine("Saving to file " + saveCommand.FileName);
+          _Diagnostics.WriteLine("Saving to file " + saveCommand.FileName);
           break;
         case ResizeCommand resizeCommand:
-          Console.WriteLine("Applying filter     : {0}", _GetManipulatorName(resizeCommand.Manipulator));
-          Console.WriteLine("  Target percentage : {0}", resizeCommand.Percentage == 0 ? "auto" : resizeCommand.Percentage + "%");
-          Console.WriteLine("  Target width      : {0}", resizeCommand.Width == 0 ? "auto" : resizeCommand.Width + "pixels");
-          Console.WriteLine("  Target height     : {0}", resizeCommand.Height == 0 ? "auto" : resizeCommand.Height + "pixels");
-          Console.WriteLine("  Hori. BPH         : {0}", resizeCommand.HorizontalBph);
-          Console.WriteLine("  Vert. BPH         : {0}", resizeCommand.VerticalBph);
-          Console.WriteLine("  Use Thresholds    : {0}", resizeCommand.UseThresholds);
-          Console.WriteLine("  Centered Grid     : {0}", resizeCommand.UseCenteredGrid);
-          Console.WriteLine("  Radius            : {0}", resizeCommand.Radius);
-          Console.WriteLine("  Repeat            : {0} times", resizeCommand.Count);
+          _Diagnostics.WriteLine("Applying filter     : {0}", _GetManipulatorName(resizeCommand.Manipulator));
+          _Diagnostics.WriteLine("  Target percentage : {0}", resizeCommand.Percentage == 0 ? "auto" : resizeCommand.Percentage + "%");
+          _Diagnostics.WriteLine("  Target width      : {0}", resizeCommand.Width == 0 ? "auto" : resizeCommand.Width + "pixels");
+          _Diagnostics.WriteLine("  Target height     : {0}", resizeCommand.Height == 0 ? "auto" : resizeCommand.Height + "pixels");
+          _Diagnostics.WriteLine("  Hori. BPH         : {0}", resizeCommand.HorizontalBph);
+          _Diagnostics.WriteLine("  Vert. BPH         : {0}", resizeCommand.VerticalBph);
+          _Diagnostics.WriteLine("  Use Thresholds    : {0}", resizeCommand.UseThresholds);
+          _Diagnostics.WriteLine("  Centered Grid     : {0}", resizeCommand.UseCenteredGrid);
+          _Diagnostics.WriteLine("  Radius            : {0}", resizeCommand.Radius);
+          _Diagnostics.WriteLine("  Repeat            : {0} times", resizeCommand.Count);
           break;
       }
     }
@@ -134,19 +145,19 @@ namespace Classes {
     /// <param name="fileName">The image file to describe.</param>
     private static void _PrintImageFileDetails(string fileName) {
       try {
-        Console.WriteLine("  File   : {0} Bytes", new FileInfo(fileName).Length);
+        _Diagnostics.WriteLine("  File   : {0} Bytes", new FileInfo(fileName).Length);
 
         // no validation and no embedded colour management - we only want the header
         using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
         using (var image = Image.FromStream(stream, false, false)) {
-          Console.WriteLine("  Width  : {0} Pixel", image.Width);
-          Console.WriteLine("  Height : {0} Pixel", image.Height);
-          Console.WriteLine("  Size   : {0:0.00} MegaPixel", image.Width * image.Height / 1000000.0);
-          Console.WriteLine("  Type   : {0}", _GetFormatDescription(image.RawFormat));
-          Console.WriteLine("  Format : {0}", image.PixelFormat);
+          _Diagnostics.WriteLine("  Width  : {0} Pixel", image.Width);
+          _Diagnostics.WriteLine("  Height : {0} Pixel", image.Height);
+          _Diagnostics.WriteLine("  Size   : {0:0.00} MegaPixel", image.Width * image.Height / 1000000.0);
+          _Diagnostics.WriteLine("  Type   : {0}", _GetFormatDescription(image.RawFormat));
+          _Diagnostics.WriteLine("  Format : {0}", image.PixelFormat);
         }
       } catch (Exception e) {
-        Console.WriteLine("  (details unavailable: {0})", e.Message);
+        _Diagnostics.WriteLine("  (details unavailable: {0})", e.Message);
       }
     }
 
@@ -184,8 +195,8 @@ namespace Classes {
         : string.Format(" in {0}, line {1}", exception.Filename, exception.LineNumber)
         ;
 
-      Console.WriteLine("ERROR{0}: {1}", origin, _GetErrorText(exception.ErrorType));
-      Console.WriteLine();
+      _Diagnostics.WriteLine("ERROR{0}: {1}", origin, _GetErrorText(exception.ErrorType));
+      _Diagnostics.WriteLine();
     }
 
     /// <summary>
@@ -225,7 +236,9 @@ namespace Classes {
     /// <summary>
     /// Shows the CLI help.
     /// </summary>
-    private static void _ShowHelp() {
+    /// <param name="writer">Where to write it: standard output when the user asked for help,
+    /// <see cref="_Diagnostics"/> when it accompanies an error.</param>
+    private static void _ShowHelp(TextWriter writer) {
 
       var longestFilterNameLength = SupportedManipulators.MANIPULATORS.Select(k => k.Key.Length).Max();
 
@@ -257,7 +270,7 @@ namespace Classes {
         .Replace("{stdin}", ScriptSerializer.STDIN_COMMAND_NAME)
         .Replace("{stdout}", ScriptSerializer.STDOUT_COMMAND_NAME)
         ;
-      Console.WriteLine(lines);
+      writer.WriteLine(lines);
     }
 
     /// <summary>

--- a/ImageResizer/Resources/CLIHelpText.txt
+++ b/ImageResizer/Resources/CLIHelpText.txt
@@ -32,6 +32,8 @@ Explanation:
 
   {stdin}         - Loads an image from STDIN.
   {stdout}        - Saves an image in Portable Network Graphics (.png) to STDOUT.
+                   STDOUT carries image data only; progress and errors go to STDERR, so the
+                   output can be piped straight into another program.
   {save}          - Saves the image in the buffer to a file.
     <target>     - the target file to write
 
@@ -73,6 +75,10 @@ Examples:
 
 The category may be left out where it is unambiguous, so this is the same filter as above.
 {location} {load} input.bmp {resize} auto "LQ 2x" {save} output.png
+
+Since STDOUT carries nothing but the image, runs can be piped into each other or into any
+other tool that reads an image from STDIN.
+{location} {load} 1.png {resize} auto "HQ 2x" {stdout} | {location} {stdin} {resize} auto "XBR 3x" {save} 2.png
 
 You can load and process multiple files at once by loading after saving again.
 {location} {load} 1.bmp {resize} 10x10 "Nearest Neighbor" {save} 1.jpg {load} 2.bmp {resize} 10x10 "Nearest Neighbor" {save} 2.jpg

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ ImageResizer.exe /load <input> /resize <dimensions> <method> /save <output>
 
 Run `ImageResizer.exe /?` to print the full help including the list of every supported filter method; with no arguments it opens the GUI.
 
+#### Piping
+
+`/stdin` reads an image from standard input and `/stdout` writes a PNG to standard output. Standard output carries image data and nothing else — progress reports and errors go to standard error — so a run can be piped straight into another program:
+
+```bash
+# chain two runs
+ImageResizer.exe /load in.png /resize auto "HQ 2x" /stdout | ImageResizer.exe /stdin /resize auto "XBR 3x" /save out.png
+
+# hand the result to another tool
+ImageResizer.exe /load in.png /resize auto "XBR 3x" /stdout | magick - out.webp
+```
+
 ### Supported Parameters
 - `radius`: Filter radius for resampling kernels
 - `thresholds`: Enable/disable similarity thresholds

--- a/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
+++ b/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
@@ -69,10 +69,34 @@ namespace ImageResizer.Tests {
     /// <summary>The outcome of one process run.</summary>
     private sealed class RunResult {
       public int ExitCode { get; set; }
-      public string StandardOutput { get; set; }
+
+      /// <summary>
+      /// Standard output verbatim. Kept as bytes because it carries image data whenever /stdout
+      /// is in play, and decoding that as text would mangle it.
+      /// </summary>
+      public byte[] StandardOutputBytes { get; set; }
+
       public string StandardError { get; set; }
 
+      public string StandardOutput => Encoding.UTF8.GetString(this.StandardOutputBytes);
+
       public CLIExitCode Code => (CLIExitCode)this.ExitCode;
+
+      /// <summary>Whether standard output is exactly one PNG and nothing else.</summary>
+      public bool StandardOutputIsPng
+        => this.StandardOutputBytes.Length > 8 && this.StandardOutputBytes.Take(8).SequenceEqual(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A })
+      ;
+
+      /// <summary>The dimensions in the IHDR chunk of the PNG on standard output.</summary>
+      public Size StandardOutputPngSize {
+        get {
+          var header = this.StandardOutputBytes;
+          return new Size(
+            (header[16] << 24) | (header[17] << 16) | (header[18] << 8) | header[19],
+            (header[20] << 24) | (header[21] << 16) | (header[22] << 8) | header[23]
+          );
+        }
+      }
     }
 
     /// <summary>
@@ -80,7 +104,15 @@ namespace ImageResizer.Tests {
     /// </summary>
     /// <param name="arguments">The arguments, each quoted as needed.</param>
     /// <returns>The outcome.</returns>
-    private RunResult _Run(params string[] arguments) {
+    private RunResult _Run(params string[] arguments) => this._RunWithInput(null, arguments);
+
+    /// <summary>
+    /// Runs the executable, optionally feeding it standard input.
+    /// </summary>
+    /// <param name="standardInput">Bytes to pipe in, or <c>null</c> for no input.</param>
+    /// <param name="arguments">The arguments.</param>
+    /// <returns>The outcome.</returns>
+    private RunResult _RunWithInput(byte[] standardInput, params string[] arguments) {
       var startInfo = new ProcessStartInfo(_EXECUTABLE) {
         Arguments = string.Join(" ", arguments.Select(_Quote)),
         WorkingDirectory = this._directory.Path,
@@ -88,21 +120,29 @@ namespace ImageResizer.Tests {
         CreateNoWindow = true,
         RedirectStandardOutput = true,
         RedirectStandardError = true,
+        RedirectStandardInput = standardInput != null,
       };
 
       using (var process = Process.Start(startInfo)) {
-        // read both pipes before waiting, or a full buffer deadlocks the child
-        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        // drain both pipes before waiting, or a full buffer deadlocks the child
+        var standardOutput = new MemoryStream();
+        var outputPump = process.StandardOutput.BaseStream.CopyToAsync(standardOutput);
         var standardError = process.StandardError.ReadToEndAsync();
+
+        if (standardInput != null)
+          using (var input = process.StandardInput.BaseStream)
+            input.Write(standardInput, 0, standardInput.Length);
 
         if (!process.WaitForExit(_TIMEOUT_MILLISECONDS)) {
           process.Kill();
           Assert.Fail("the executable did not terminate within {0} ms", _TIMEOUT_MILLISECONDS);
         }
 
+        outputPump.Wait(_TIMEOUT_MILLISECONDS);
+
         return new RunResult {
           ExitCode = process.ExitCode,
-          StandardOutput = standardOutput.Result,
+          StandardOutputBytes = standardOutput.ToArray(),
           StandardError = standardError.Result,
         };
       }
@@ -130,7 +170,7 @@ namespace ImageResizer.Tests {
     public void LoadAndSave_CopiesTheImageThrough() {
       var result = this._Run("/load", this._Source(), "/save", "out.png");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(16, 16)));
     }
 
@@ -139,7 +179,7 @@ namespace ImageResizer.Tests {
     public void TheCommandLineFromIssue33_Works() {
       var result = this._Run("/load", this._Source(), "/resize", "auto", "HQ 2x", "/save", "out.png");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(32, 32)));
     }
 
@@ -152,7 +192,7 @@ namespace ImageResizer.Tests {
     public void FixedFactorUpscalers_ProduceTheirFactor(string filter, int expectedWidth, int expectedHeight) {
       var result = this._Run("/load", this._Source(), "/resize", "auto", filter, "/save", "out.png");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(expectedWidth, expectedHeight)));
     }
 
@@ -164,7 +204,7 @@ namespace ImageResizer.Tests {
     public void EveryDimensionForm_ReachesItsTarget(string dimensions, int expectedWidth, int expectedHeight) {
       var result = this._Run("/load", this._Source(), "/resize", dimensions, "Resampler: Bicubic", "/save", "out.png");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(expectedWidth, expectedHeight)));
     }
 
@@ -172,7 +212,7 @@ namespace ImageResizer.Tests {
     public void FiltersChain_LeftToRight() {
       var result = this._Run("/load", this._Source(), "/resize", "auto", "XBR 3x", "/resize", "w128", "Bicubic", "/save", "out.png");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._SizeOf("out.png").Width, Is.EqualTo(128));
     }
 
@@ -180,7 +220,7 @@ namespace ImageResizer.Tests {
     public void SeveralSavesInOneRun_AllProduceFiles() {
       var result = this._Run("/load", this._Source(), "/resize", "auto", "HQ 2x", "/save", "a.png", "/save", "b.bmp");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._Exists("a.png"), Is.True);
       Assert.That(this._Exists("b.bmp"), Is.True);
     }
@@ -195,7 +235,7 @@ namespace ImageResizer.Tests {
         "/load", "two.png", "/resize", "auto", "HQ 2x", "/save", "two-out.png"
       );
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._SizeOf("one-out.png"), Is.EqualTo(new Size(16, 16)));
       Assert.That(this._SizeOf("two-out.png"), Is.EqualTo(new Size(24, 24)));
     }
@@ -208,7 +248,7 @@ namespace ImageResizer.Tests {
     public void TheOutputExtension_PicksTheContainerFormat(string target) {
       var result = this._Run("/load", this._Source(), "/save", target);
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(TestBitmaps.RawFormatOf(this._directory.File(target)), Is.EqualTo(TestBitmaps.FormatFor(target)));
     }
 
@@ -218,7 +258,7 @@ namespace ImageResizer.Tests {
 
       var result = this._Run("/load", "my source.png", "/save", "my target.png");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._Exists("my target.png"), Is.True);
     }
 
@@ -226,7 +266,7 @@ namespace ImageResizer.Tests {
     public void FilterParameters_AreAccepted() {
       var result = this._Run("/load", this._Source(), "/resize", "32x32", "Resampler: Bicubic(vbounds=wrap,hbounds=wrap,centered=0)", "/save", "out.png");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(32, 32)));
     }
 
@@ -241,7 +281,7 @@ namespace ImageResizer.Tests {
 
       var result = this._Run("/script", "chain.irs");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(64, 64)));
     }
 
@@ -252,7 +292,7 @@ namespace ImageResizer.Tests {
 
       var result = this._Run("/load", "in.png", "/script", "filter.irs", "/save", "out.png");
 
-      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardOutput);
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
       Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(32, 32)));
     }
 
@@ -263,7 +303,7 @@ namespace ImageResizer.Tests {
       var result = this._Run("/script", "bad.irs");
 
       Assert.That(result.Code, Is.EqualTo(CLIExitCode.UnknownFilter));
-      Assert.That(result.StandardOutput, Does.Contain("bad.irs"));
+      Assert.That(result.StandardError, Does.Contain("bad.irs"));
     }
 
     #endregion
@@ -279,7 +319,7 @@ namespace ImageResizer.Tests {
       var result = this._Run(switchText);
 
       Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK));
-      Assert.That(result.StandardOutput, Does.Contain("How to use"));
+      Assert.That(result.StandardOutput, Does.Contain("How to use"), "help that was asked for is the run's output");
     }
 
     [Test]
@@ -306,7 +346,7 @@ namespace ImageResizer.Tests {
       var result = this._Run("/frobnicate", "in.png");
 
       Assert.That(result.Code, Is.EqualTo(CLIExitCode.UnknownParameter));
-      Assert.That(result.StandardOutput, Does.Contain("ERROR"));
+      Assert.That(result.StandardError, Does.Contain("ERROR"));
     }
 
     [Test]
@@ -314,7 +354,7 @@ namespace ImageResizer.Tests {
       var result = this._Run("/load", this._Source(), "/resize", "auto", "NoSuchFilter", "/save", "out.png");
 
       Assert.That(result.Code, Is.EqualTo(CLIExitCode.UnknownFilter));
-      Assert.That(result.StandardOutput, Does.Contain("ERROR"));
+      Assert.That(result.StandardError, Does.Contain("ERROR"));
       Assert.That(this._Exists("out.png"), Is.False, "nothing may be written when the script never parsed");
     }
 
@@ -378,7 +418,75 @@ namespace ImageResizer.Tests {
     public void AFailingRun_StillPrintsTheHelpSoTheUserCanRecover() {
       var result = this._Run("/load", this._Source(), "/resize", "auto", "NoSuchFilter");
 
-      Assert.That(result.StandardOutput, Does.Contain("How to use"));
+      Assert.That(result.StandardError, Does.Contain("How to use"));
+    }
+
+    #endregion
+
+    #region piping
+
+    /// <summary>
+    /// Regression for issue #15: the progress reports used to go to standard output, so whatever
+    /// consumed the pipe received several hundred bytes of text where it expected a PNG header.
+    /// </summary>
+    [Test]
+    public void StdOut_CarriesNothingButTheImage() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "HQ 2x", "/stdout");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      Assert.That(result.StandardOutputIsPng, Is.True, "standard output must start with the PNG signature, not with a progress report");
+      Assert.That(result.StandardOutputPngSize, Is.EqualTo(new Size(32, 32)));
+    }
+
+    [Test]
+    public void StdOut_KeepsTheDiagnosticsOnStandardError() {
+      var result = this._Run("/load", this._Source(), "/stdout");
+
+      Assert.That(result.StandardError, Does.Contain("Executing the following script"));
+      Assert.That(result.StandardOutputIsPng, Is.True);
+    }
+
+    [Test]
+    public void StdIn_ReadsAnImageFromThePipe() {
+      var source = File.ReadAllBytes(this._directory.File(this._Source()));
+
+      var result = this._RunWithInput(source, "/stdin", "/resize", "auto", "HQ 2x", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(32, 32)));
+    }
+
+    /// <summary>
+    /// The end-to-end shape issue #15 was really about: one instance's output feeding the next.
+    /// </summary>
+    [Test]
+    public void StdOutOfOneRun_FeedsStdInOfTheNext() {
+      var first = this._Run("/load", this._Source(), "/resize", "auto", "HQ 2x", "/stdout");
+
+      var second = this._RunWithInput(first.StandardOutputBytes, "/stdin", "/resize", "auto", "XBR 3x", "/stdout");
+
+      Assert.That(second.Code, Is.EqualTo(CLIExitCode.OK), second.StandardError);
+      Assert.That(second.StandardOutputIsPng, Is.True);
+      Assert.That(second.StandardOutputPngSize, Is.EqualTo(new Size(96, 96)), "16 through HQ 2x is 32, through XBR 3x is 96");
+    }
+
+    [Test]
+    public void SeveralStdOutCommands_EachEmitAnImage() {
+      var single = this._Run("/load", this._Source(), "/stdout");
+
+      var twice = this._Run("/load", this._Source(), "/stdout", "/stdout");
+
+      Assert.That(twice.Code, Is.EqualTo(CLIExitCode.OK), twice.StandardError);
+      Assert.That(twice.StandardOutputBytes.Length, Is.EqualTo(single.StandardOutputBytes.Length * 2));
+    }
+
+    [Test]
+    public void AFailingRun_LeavesStandardOutputEmpty() {
+      var result = this._Run("/load", this._Source(), "/resize", "auto", "NoSuchFilter", "/stdout");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.UnknownFilter));
+      Assert.That(result.StandardOutputBytes, Is.Empty, "a consumer of the pipe must not receive the help text");
+      Assert.That(result.StandardError, Is.Not.Empty);
     }
 
     #endregion
@@ -389,22 +497,22 @@ namespace ImageResizer.Tests {
     public void TheRunEchoesTheScriptItIsAboutToExecute() {
       var result = this._Run("/load", this._Source(), "/save", "out.png");
 
-      Assert.That(result.StandardOutput, Does.Contain("Executing the following script"));
+      Assert.That(result.StandardError, Does.Contain("Executing the following script"));
     }
 
     [Test]
     public void LoadDiagnostics_ReportTheRealContainerFormat() {
       var result = this._Run("/load", this._Source(), "/save", "out.png");
 
-      Assert.That(result.StandardOutput, Does.Contain("Type   : PNG"), "MemoryBmp here would mean the in-memory copy is being described");
-      Assert.That(result.StandardOutput, Does.Not.Contain("details unavailable"));
+      Assert.That(result.StandardError, Does.Contain("Type   : PNG"), "MemoryBmp here would mean the in-memory copy is being described");
+      Assert.That(result.StandardError, Does.Not.Contain("details unavailable"));
     }
 
     [Test]
     public void ResizeDiagnostics_NameTheFilterThatRan() {
       var result = this._Run("/load", this._Source(), "/resize", "auto", "HQ 2x", "/save", "out.png");
 
-      Assert.That(result.StandardOutput, Does.Contain("Upscaler: HQ 2x"), "the canonical name, not the abbreviation that was typed");
+      Assert.That(result.StandardError, Does.Contain("Upscaler: HQ 2x"), "the canonical name, not the abbreviation that was typed");
     }
 
     #endregion


### PR DESCRIPTION
Closes #15.

## Cause

`/stdout` writes a PNG to standard output — but the script echo and every per-step diagnostic went to that same stream. Measured on the reporter's shape of command:

```
$ ImageResizer.exe /load in.png /resize auto "HQ 2x" /stdout > out.bin
stdout bytes: 840
PNG magic at offset: 566      <- 566 bytes of text ahead of the image
stderr bytes: 0
```

So the consumer of the pipe was handed text where it expected a PNG header. That is exactly the `convert.exe: no decode delegate for this image format` in the report — ImageMagick was reading `Executing the following script:`, not an image.

## Change

Diagnostics and errors go to standard error. Standard output carries image data and nothing else.

Help stays on standard output when it was *asked for* with `/?`, since then it is the output of the run; the help that accompanies a parse error goes to standard error with the error.

After:

```
stdout bytes: 274
PNG magic at offset: 0        <- clean
stderr bytes: 566
```

## Verification

Chaining two instances through a pipe — the shape this issue is really about — now works:

```bash
ImageResizer.exe /load in.png /resize auto "HQ 2x" /stdout | ImageResizer.exe /stdin /resize auto "XBR 3x" /stdout > out.png
# 16 -> HQ 2x -> 32 -> XBR 3x -> 96x96, valid PNG
```

Six new end-to-end cases pin it: standard output is exactly a PNG, a failed run leaves it empty, `/stdin` reads one back, one run's output feeds the next, repeated `/stdout` emits one image each, and the diagnostics are on standard error. **234 tests green.**

The E2E harness now captures standard output as *bytes* rather than decoded text — decoding it would have mangled the very thing under test.

## Note

This changes what `> file` captures: it now gets the image, not the log. That is the point of the fix and matches the convention, but it is a visible behaviour change for anyone who was redirecting stdout to collect progress output. Documented in the help text and the README.