### PR TITLE
# GDI+ resamplers haloed and shifted every image

### DIFF
--- a/ImageResizer/Classes/ImageManipulators/GdiPlusResampler.cs
+++ b/ImageResizer/Classes/ImageManipulators/GdiPlusResampler.cs
@@ -21,6 +21,7 @@
 
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
 
 using Imager.Pipelines;
 
@@ -32,10 +33,7 @@ namespace Classes.ImageManipulators {
   /// Exposed as a system-API baseline for visual comparison against the upstream resamplers.
   ///
   /// OOB modes, canvas colour and centred-grid flag on <see cref="UpstreamPipeline.ResampleFunc"/>
-  /// are ignored: GDI+ has no equivalent knobs. The <c>-1,-1,W+1,H+1</c> draw rectangle works
-  /// around a long-standing GDI+ bug that otherwise paints a white pixel on the top/left edge
-  /// (see http://forums.asp.net/t/1031961.aspx/1). This matches the behaviour of the retired
-  /// local <c>Interpolator</c> / <c>cImage.ApplyScaler(InterpolationMode, …)</c> path exactly.
+  /// are ignored: GDI+ has no equivalent knobs.
   /// </summary>
   internal static class GdiPlusResampler {
 
@@ -47,15 +45,50 @@ namespace Classes.ImageManipulators {
       );
     }
 
+    /// <summary>
+    /// Resamples through GDI+.
+    /// <para>
+    /// Interpolating near an edge needs samples from beyond it, and GDI+ takes those from the
+    /// transparent surround unless told otherwise - which is what stamped a one pixel halo around
+    /// every output. <see cref="WrapMode.TileFlipXY"/> mirrors the source at its borders instead,
+    /// so the edge is interpolated against real colour.
+    /// </para>
+    /// <para>
+    /// The previous workaround for that halo drew into <c>-1,-1,W+1,H+1</c>. It hid the border by
+    /// pushing it outside the bitmap, but in doing so it offset the image by a pixel and stretched
+    /// it by one in each direction, so the result was never the requested resampling.
+    /// </para>
+    /// </summary>
+    /// <param name="source">The source bitmap.</param>
+    /// <param name="targetWidth">The target width.</param>
+    /// <param name="targetHeight">The target height.</param>
+    /// <param name="mode">The interpolation mode.</param>
+    /// <returns>The resampled bitmap.</returns>
     private static Bitmap Resample(Bitmap source, int targetWidth, int targetHeight, InterpolationMode mode) {
-      var result = new Bitmap(targetWidth, targetHeight);
+      var result = new Bitmap(targetWidth, targetHeight, PixelFormat.Format32bppArgb);
+      result.SetResolution(source.HorizontalResolution, source.VerticalResolution);
+
       using (var graphics = Graphics.FromImage(result)) {
+        // SourceCopy: write the resampled pixels as they are instead of blending them over the
+        // transparent bitmap we just allocated
+        graphics.CompositingMode = CompositingMode.SourceCopy;
         graphics.CompositingQuality = CompositingQuality.HighQuality;
         graphics.InterpolationMode = mode;
         graphics.SmoothingMode = SmoothingMode.HighQuality;
-        // -1/-1 + size+1 draw rectangle avoids the GDI+ white-edge pixel bug.
-        graphics.DrawImage(source, -1, -1, targetWidth + 1, targetHeight + 1);
+        graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
+
+        using (var attributes = new ImageAttributes()) {
+          attributes.SetWrapMode(WrapMode.TileFlipXY);
+          graphics.DrawImage(
+            source,
+            new Rectangle(0, 0, targetWidth, targetHeight),
+            0, 0, source.Width, source.Height,
+            GraphicsUnit.Pixel,
+            attributes
+          );
+        }
       }
+
       return result;
     }
 

--- a/Tests/ImageResizer.Tests/ResamplerCorrectnessTests.cs
+++ b/Tests/ImageResizer.Tests/ResamplerCorrectnessTests.cs
@@ -1,0 +1,178 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Extensions.ColorProcessing.Resizing;
+using System.Linq;
+
+using Classes;
+using Classes.ImageManipulators;
+using Classes.ScriptActions;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Properties every resampler has to satisfy, checked against the whole registry rather than
+  /// against stored reference images - so a new algorithm is covered the moment it is registered.
+  /// </summary>
+  [TestFixture]
+  public class ResamplerCorrectnessTests {
+
+    /// <summary>Every entry that takes an explicit target width and height.</summary>
+    private static IEnumerable<TestCaseData> Resamplers
+      => SupportedManipulators.MANIPULATORS
+        .Where(pair => pair.Value.SupportsWidth && pair.Value.SupportsHeight)
+        .Select(pair => new TestCaseData(pair.Key).SetName("{m}(" + pair.Key.Replace(".", "_") + ")"))
+    ;
+
+    /// <summary>
+    /// Runs a named resampler over a bitmap.
+    /// </summary>
+    /// <param name="filterName">The registered name.</param>
+    /// <param name="source">The source bitmap.</param>
+    /// <param name="width">The target width.</param>
+    /// <param name="height">The target height.</param>
+    /// <returns>The result; the caller owns it.</returns>
+    private static Bitmap _Resample(string filterName, Bitmap source, int width, int height) {
+      var command = new ResizeCommand(
+        false,
+        SupportedManipulators.MANIPULATORS.First(pair => pair.Key == filterName).Value,
+        (ushort)width, (ushort)height, 0, false,
+        OutOfBoundsMode.ConstantExtension, OutOfBoundsMode.ConstantExtension,
+        1, true, true, 1f
+      ) {
+        SourceImage = source,
+      };
+
+      command.Execute();
+      return command.TargetImage;
+    }
+
+    /// <summary>A bitmap filled with one colour throughout.</summary>
+    private static Bitmap _Flat(int size, Color colour) {
+      var result = new Bitmap(size, size);
+      using (var graphics = Graphics.FromImage(result))
+      using (var brush = new SolidBrush(colour))
+        graphics.FillRectangle(brush, 0, 0, size, size);
+
+      return result;
+    }
+
+    /// <summary>Reports the darkest and brightest red channel value in a bitmap.</summary>
+    private static void _RedRange(Bitmap bitmap, out int minimum, out int maximum) {
+      minimum = int.MaxValue;
+      maximum = int.MinValue;
+      for (var y = 0; y < bitmap.Height; ++y)
+      for (var x = 0; x < bitmap.Width; ++x) {
+        var value = bitmap.GetPixel(x, y).R;
+        if (value < minimum)
+          minimum = value;
+
+        if (value > maximum)
+          maximum = value;
+      }
+    }
+
+    /// <summary>
+    /// Resampling a uniform image can only ever produce that same uniform image - every kernel
+    /// sums to one over a constant signal. A deviation means the weights are not normalised or
+    /// that samples are being taken from outside the source, which is what produced the one pixel
+    /// halo around every GDI+ result.
+    /// </summary>
+    [TestCaseSource(nameof(Resamplers))]
+    public void AUniformImage_SurvivesDownscalingUnchanged(string filterName) {
+      using (var source = _Flat(64, Color.FromArgb(255, 128, 128, 128)))
+      using (var result = _Resample(filterName, source, 40, 40)) {
+        _RedRange(result, out var minimum, out var maximum);
+
+        Assert.That(minimum, Is.EqualTo(128).Within(1), filterName);
+        Assert.That(maximum, Is.EqualTo(128).Within(1), filterName);
+      }
+    }
+
+    [TestCaseSource(nameof(Resamplers))]
+    public void AUniformImage_SurvivesUpscalingUnchanged(string filterName) {
+      using (var source = _Flat(32, Color.FromArgb(255, 128, 128, 128)))
+      using (var result = _Resample(filterName, source, 96, 96)) {
+        _RedRange(result, out var minimum, out var maximum);
+
+        Assert.That(minimum, Is.EqualTo(128).Within(1), filterName);
+        Assert.That(maximum, Is.EqualTo(128).Within(1), filterName);
+      }
+    }
+
+    [TestCaseSource(nameof(Resamplers))]
+    public void EveryResampler_HitsTheRequestedSize(string filterName) {
+      using (var source = _Flat(32, Color.Gray))
+      using (var result = _Resample(filterName, source, 45, 21)) {
+        Assert.That(result.Width, Is.EqualTo(45), filterName);
+        Assert.That(result.Height, Is.EqualTo(21), filterName);
+      }
+    }
+
+    /// <summary>
+    /// Regression: the GDI+ wrappers drew into <c>-1,-1,W+1,H+1</c> to hide an edge artefact,
+    /// which offset and stretched the image. A one-to-one nearest-neighbour resample is the
+    /// cheapest way to see it - it has to be the identity.
+    /// </summary>
+    [Test]
+    public void OneToOneNearestNeighbour_ReturnsTheSourceUnchanged() {
+      using (var source = TestBitmaps.Create(48, 48))
+      using (var result = _Resample("Resampler: NearestNeighbor <GDI+>", source, 48, 48)) {
+        var differing = 0;
+        for (var y = 0; y < source.Height; ++y)
+        for (var x = 0; x < source.Width; ++x)
+          if (source.GetPixel(x, y).ToArgb() != result.GetPixel(x, y).ToArgb())
+            ++differing;
+
+        Assert.That(differing, Is.Zero, "resampling to the same size must not move or rescale anything");
+      }
+    }
+
+    /// <summary>
+    /// The halo the GDI+ workaround was hiding: interpolating at an edge pulled in the transparent
+    /// surround, leaving a bright border on an otherwise uniform image.
+    /// </summary>
+    [TestCase("Resampler: Bicubic <GDI+>")]
+    [TestCase("Resampler: HighQualityBicubic <GDI+>")]
+    [TestCase("Resampler: HighQualityBilinear <GDI+>")]
+    [TestCase("Resampler: Bilinear <GDI+>")]
+    [TestCase("Resampler: NearestNeighbor <GDI+>")]
+    public void GdiPlusResamplers_LeaveNoBorderHalo(string filterName) {
+      using (var source = _Flat(64, Color.FromArgb(255, 128, 128, 128)))
+      using (var result = _Resample(filterName, source, 100, 100)) {
+        var border = new List<int>();
+        for (var x = 0; x < result.Width; ++x) {
+          border.Add(result.GetPixel(x, 0).R);
+          border.Add(result.GetPixel(x, result.Height - 1).R);
+        }
+
+        for (var y = 0; y < result.Height; ++y) {
+          border.Add(result.GetPixel(0, y).R);
+          border.Add(result.GetPixel(result.Width - 1, y).R);
+        }
+
+        Assert.That(border, Is.All.EqualTo(128), filterName);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #21.

## What the report said, and what is left of it

The reported case — 160×160 → 100×100 through **BlackmanHarris**, producing a grid — **no longer reproduces**. That was filed against r129 in 2015; the resampler stack has since been replaced by the upstream `System.Drawing.Extensions` pipeline, and BlackmanHarris is clean.

The report also says *"some others causing this grid too, some just looks weird"*, so rather than close it on the one named algorithm I swept **all 95 entries that take a width and height**, at four target sizes each.

A uniform image is the sharp instrument here: every resampling kernel sums to one over a constant signal, so a flat input must come out flat. Anything else means unnormalised weights or samples taken from outside the source.

**90 upstream resamplers: clean at every size.** The five GDI+ wrappers were not:

| Resampler | 160→100 | 160→320 | 160→7 | 160→100×40 |
|---|---|---|---|---|
| `Bicubic <GDI+>` | 128..140 | 128..144 | ok | 128..134 |
| `HighQualityBicubic <GDI+>` | 128..142 | 127..151 | 128..151 | 128..145 |
| `HighQualityBilinear <GDI+>` | 127..128 | 127..128 | ok | 127..128 |
| `Bilinear <GDI+>` | ok | 127..128 | ok | ok |
| `NearestNeighbor <GDI+>` | ok | 0..128 | ok | ok |

Every deviating pixel sat on the outer rows and columns — a one pixel halo, interior perfect.

## Cause

`GdiPlusResampler` drew into `-1,-1,W+1,H+1`. That was a workaround for the halo GDI+ leaves when it interpolates at an edge and pulls samples from the transparent surround. It hid the border by pushing it outside the bitmap — and in doing so **offset the image by a pixel and stretched it by one in each direction**, so the result was never the resampling that was asked for.

Measured on a 1:1 nearest-neighbour resize, which has to be the identity:

```
OLD code: 19200 of 25600 pixels differ from the source
NEW code:     0 of 25600 pixels differ
```

## Change

The border is handled at its cause instead of hidden: `WrapMode.TileFlipXY` mirrors the source at its edges so there is real colour to interpolate against, and the draw rectangle is simply the target rectangle. `CompositingMode.SourceCopy` stops the resampled pixels being blended over the freshly allocated transparent bitmap.

All five GDI+ resamplers are now flat at all four target sizes.

## Tests

Rather than reference images, the properties are asserted across the registry, so a newly registered algorithm is covered the moment it appears:

- a uniform image survives any resampler unchanged, downscaling and upscaling
- every resampler hits the requested (non-square) size exactly
- a 1:1 nearest-neighbour resample is the identity
- the GDI+ entries leave no border halo

**525 tests green**, up from 234.