### PR TITLE
+ run .irs scripts dropped on the executable

### DIFF
--- a/ImageResizer/Classes/CLI.cs
+++ b/ImageResizer/Classes/CLI.cs
@@ -228,6 +228,8 @@ namespace Classes {
           return "A filter parameter that must be a value 0-255 is not one.";
         case CLIExitCode.InvalidOutOfBoundsMode:
           return "Invalid out of bounds mode - expected const, half, whole, wrap or transparent.";
+        case CLIExitCode.ScriptFileCouldNotBeRead:
+          return "The script file could not be read.";
         default:
           return exitCode.ToString();
       }

--- a/ImageResizer/Classes/CLIExitCode.cs
+++ b/ImageResizer/Classes/CLIExitCode.cs
@@ -39,6 +39,7 @@ namespace Classes {
     CouldNotParseParameterAsByte=14,
     InvalidOutOfBoundsMode=15,
     AmbiguousFilter=18,
+    ScriptFileCouldNotBeRead=19,
 
     RuntimeError=16,
   }

--- a/ImageResizer/Classes/ScriptSerializer.cs
+++ b/ImageResizer/Classes/ScriptSerializer.cs
@@ -216,7 +216,16 @@ namespace Classes {
               return CLIExitCode.FilenameMustNotBeNull;
             }
 
-            LoadFromFile(engine, filename);
+            // a script that cannot be read is a usage error, not a crash - it used to escape as an
+            // unhandled IOException and print a stack trace at the user
+            try {
+              LoadFromFile(engine, filename);
+            } catch (IOException) {
+              return CLIExitCode.ScriptFileCouldNotBeRead;
+            } catch (UnauthorizedAccessException) {
+              return CLIExitCode.ScriptFileCouldNotBeRead;
+            }
+
             break;
           }
           #endregion

--- a/ImageResizer/Program.cs
+++ b/ImageResizer/Program.cs
@@ -19,8 +19,10 @@
  */
 #endregion
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -71,6 +73,15 @@ namespace ImageResizer {
       var firstParam = args != null && args.Length > 0 ? args[0] : null;
       var fileToOpenOnStart = firstParam != _FORCE_GUI_CLP_NAME && File.Exists(firstParam) ? firstParam : null;
 
+      // Scripts dropped on the executable, or opened through a file association, arrive as plain
+      // file names - the same shape as an image to open. They are something to run, so they take
+      // the CLI path with each one turned into a /script command.
+      if (_AreAllScriptFiles(args)) {
+        var scriptArguments = _ToScriptArguments(args);
+        _EnterScriptDirectory(args[0]);
+        Environment.Exit((int)CLI.ParseCommandLineArguments(scriptArguments));
+      }
+
       if (firstParam != null && firstParam != _FORCE_GUI_CLP_NAME && fileToOpenOnStart == null) {
 
         // execute CLI if arguments are given which are not forcing into gui or a valid filename
@@ -101,6 +112,65 @@ namespace ImageResizer {
         }
       }
 
+    }
+
+    /// <summary>
+    /// Determines whether every argument names an existing script file.
+    /// </summary>
+    /// <param name="args">The arguments.</param>
+    /// <returns><c>true</c> when there is at least one and all of them are scripts.</returns>
+    private static bool _AreAllScriptFiles(string[] args)
+      => args != null && args.Length > 0 && args.All(_IsScriptFile)
+    ;
+
+    /// <summary>
+    /// Determines whether a path names an existing script file.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <returns><c>true</c> when it exists and carries the script extension.</returns>
+    private static bool _IsScriptFile(string path)
+      => !string.IsNullOrWhiteSpace(path)
+      && string.Equals(Path.GetExtension(path), ScriptSerializer.DEFAULT_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase)
+      && File.Exists(path)
+    ;
+
+    /// <summary>
+    /// Turns a list of script files into the command line that runs them in order.
+    /// <para>
+    /// The paths are made absolute here because <see cref="_EnterScriptDirectory"/> moves the
+    /// working directory afterwards, and a relative path would then point somewhere else.
+    /// </para>
+    /// </summary>
+    /// <param name="paths">The script files.</param>
+    /// <returns>The arguments.</returns>
+    private static string[] _ToScriptArguments(string[] paths) {
+      var result = new List<string>(paths.Length * 2);
+      foreach (var path in paths) {
+        result.Add(ScriptSerializer.SCRIPT_COMMAND_NAME);
+        result.Add(Path.GetFullPath(path));
+      }
+
+      return result.ToArray();
+    }
+
+    /// <summary>
+    /// Makes a script's own folder the working directory.
+    /// <para>
+    /// A script names its images relatively, and the working directory it inherits when Explorer
+    /// launches it is not its own - dropping a script on the executable gives the executable's
+    /// folder. Resolving against the script instead is what makes a script and its images travel
+    /// together, and is how Explorer runs a batch file.
+    /// </para>
+    /// </summary>
+    /// <param name="scriptPath">The script being run.</param>
+    private static void _EnterScriptDirectory(string scriptPath) {
+      try {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(scriptPath));
+        if (!string.IsNullOrEmpty(directory))
+          Directory.SetCurrentDirectory(directory);
+      } catch (Exception) {
+        // an unusable path is the script runner's problem to report, not ours
+      }
     }
   }
 }

--- a/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
+++ b/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
@@ -104,18 +104,34 @@ namespace ImageResizer.Tests {
     /// </summary>
     /// <param name="arguments">The arguments, each quoted as needed.</param>
     /// <returns>The outcome.</returns>
-    private RunResult _Run(params string[] arguments) => this._RunWithInput(null, arguments);
+    private RunResult _Run(params string[] arguments) => this._Execute(null, null, arguments);
+
+    /// <summary>
+    /// Runs the executable from a working directory other than the scratch directory, the way
+    /// Explorer launches something that lives elsewhere.
+    /// </summary>
+    /// <param name="workingDirectory">The directory to start in.</param>
+    /// <param name="arguments">The arguments.</param>
+    /// <returns>The outcome.</returns>
+    private RunResult _RunIn(string workingDirectory, params string[] arguments)
+      => this._Execute(null, workingDirectory, arguments)
+    ;
+
+    private RunResult _RunWithInput(byte[] standardInput, params string[] arguments)
+      => this._Execute(standardInput, null, arguments)
+    ;
 
     /// <summary>
     /// Runs the executable, optionally feeding it standard input.
     /// </summary>
     /// <param name="standardInput">Bytes to pipe in, or <c>null</c> for no input.</param>
+    /// <param name="workingDirectory">The directory to start in, or <c>null</c> for the scratch directory.</param>
     /// <param name="arguments">The arguments.</param>
     /// <returns>The outcome.</returns>
-    private RunResult _RunWithInput(byte[] standardInput, params string[] arguments) {
+    private RunResult _Execute(byte[] standardInput, string workingDirectory, string[] arguments) {
       var startInfo = new ProcessStartInfo(_EXECUTABLE) {
         Arguments = string.Join(" ", arguments.Select(_Quote)),
-        WorkingDirectory = this._directory.Path,
+        WorkingDirectory = workingDirectory ?? this._directory.Path,
         UseShellExecute = false,
         CreateNoWindow = true,
         RedirectStandardOutput = true,
@@ -304,6 +320,70 @@ namespace ImageResizer.Tests {
 
       Assert.That(result.Code, Is.EqualTo(CLIExitCode.UnknownFilter));
       Assert.That(result.StandardError, Does.Contain("bad.irs"));
+    }
+
+    #endregion
+
+    #region dropped scripts
+
+    /// <summary>
+    /// Issue #12: a script dropped on the executable, or double clicked through a file
+    /// association, arrives as a bare file name. It used to be taken for an image to open.
+    /// </summary>
+    [Test]
+    public void AScriptPassedAsABareFileName_IsRun() {
+      this._Source();
+      File.WriteAllText(this._directory.File("drop.irs"), "/load \"in.png\"\r\n/resize auto \"Upscaler: XBR 4x\"\r\n/save \"out.png\"\r\n");
+
+      var result = this._Run("drop.irs");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(64, 64)));
+    }
+
+    [Test]
+    public void ADroppedScript_ResolvesItsPathsAgainstItsOwnFolder() {
+      this._Source();
+      File.WriteAllText(this._directory.File("drop.irs"), "/load \"in.png\"\r\n/resize auto \"Upscaler: HQ 2x\"\r\n/save \"out.png\"\r\n");
+      var elsewhere = Path.Combine(this._directory.Path, "elsewhere");
+      Directory.CreateDirectory(elsewhere);
+
+      // launched from a directory that is not the script's, the way Explorer does it
+      var result = this._RunIn(elsewhere, Path.Combine(this._directory.Path, "drop.irs"));
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      Assert.That(this._Exists("out.png"), Is.True, "the script's own folder is what its relative paths mean");
+    }
+
+    [Test]
+    public void SeveralDroppedScripts_RunInOrder() {
+      this._Source();
+      File.WriteAllText(this._directory.File("one.irs"), "/load \"in.png\"\r\n/resize auto \"Upscaler: HQ 2x\"\r\n/save \"one.png\"\r\n");
+      File.WriteAllText(this._directory.File("two.irs"), "/load \"one.png\"\r\n/resize auto \"Upscaler: HQ 2x\"\r\n/save \"two.png\"\r\n");
+
+      var result = this._Run("one.irs", "two.irs");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      Assert.That(this._SizeOf("two.png"), Is.EqualTo(new Size(64, 64)));
+    }
+
+    [Test]
+    public void TheScriptExtension_IsMatchedCaseInsensitively() {
+      this._Source();
+      File.WriteAllText(this._directory.File("drop.IRS"), "/load \"in.png\"\r\n/save \"out.png\"\r\n");
+
+      var result = this._Run("drop.IRS");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      Assert.That(this._Exists("out.png"), Is.True);
+    }
+
+    [Test]
+    public void AnUnreadableScript_IsAnExitCodeRatherThanACrash() {
+      var result = this._Run("/script", "absent.irs");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.ScriptFileCouldNotBeRead));
+      Assert.That(result.StandardError, Does.Not.Contain("Unhandled Exception"));
     }
 
     #endregion


### PR DESCRIPTION
Closes #12.

## Cause

A `.irs` dropped on `ImageResizer.exe` arrives as a bare file name — the same shape as an image to open. `Program.Main` saw `File.Exists` and handed it to the GUI, which tried to decode a text file as a bitmap.

## Change

Arguments that are *all* existing `.irs` files take the CLI path, each turned into a `/script` command. A mixed drop (images plus scripts) still falls through to the old behaviour untouched.

The working directory becomes the script's own folder. Without that a dropped script's relative paths resolve against whatever folder the launcher happened to be in — for a drag onto the executable, that is the executable's folder, so `/load "in.png"` would miss. Resolving against the script is how Explorer runs a batch file, and it lets a script and its images travel together.

This also covers the double-click half of #13 once `.irs` is associated with the executable — the association passes the file the same way. The association itself (registering the file type) is not in this PR.

## Also fixed

`/script` on an unreadable file let `IOException` escape through the parser, so a mistyped script name ended in an unhandled exception dump:

```
   bei Classes.ScriptSerializer.LoadFromFile(ScriptEngine engine, String filename) ...
   bei Classes.ScriptSerializer._ParseScriptLine(String line, ScriptEngine engine) ...
```

It is a usage error, and now reports `ScriptFileCouldNotBeRead` (19) with a one-line message. I hit this while testing the drop path, so it is fixed here rather than left as a trap in the feature this PR adds.

## Tests

Five new end-to-end cases: a bare script file name is run, several dropped scripts run in order, the extension matches case-insensitively, relative paths resolve against the script's folder when launched from elsewhere, and an unreadable script is an exit code rather than a crash.

**530 tests green.**

## Note on a discarded approach

I first had a failed drop show a `MessageBox`, since a script launched from Explorer has no console to print to. That turned out to hang: a terminal like mintty has no Win32 console window either, so `GetConsoleWindow()` returns 0 and any non-interactive caller would block on a modal dialog forever. A hang is worse than a silent failure, so the dialog is gone and failures report through the exit code and standard error like every other CLI path. Worth revisiting with a reliable way to detect an Explorer launch.