### PR TITLE
+ category selector for the method dropdown

### DIFF
--- a/ImageResizer/Classes/ManipulatorCategories.cs
+++ b/ImageResizer/Classes/ManipulatorCategories.cs
@@ -1,0 +1,107 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Classes {
+  /// <summary>
+  /// Splits the manipulator registry by the category each entry is registered under, so the
+  /// method dropdown can show one group at a time instead of several hundred entries at once.
+  /// <para>
+  /// Categories are derived when the registry is built, never hard-coded here - a new one appears
+  /// in the list as soon as something is registered under it.
+  /// </para>
+  /// </summary>
+  internal static class ManipulatorCategories {
+
+    /// <summary>
+    /// The pseudo-category that selects everything.
+    /// </summary>
+    public const string ALL = "(all)";
+
+    /// <summary>
+    /// Gets the category an entry belongs to.
+    /// </summary>
+    /// <param name="key">The registered name, e.g. <c>"Upscaler: HQ 2x"</c>.</param>
+    /// <returns>The category, or <c>null</c> when the name carries none.</returns>
+    public static string GetCategory(string key) {
+      if (key == null)
+        return null;
+
+      var index = key.IndexOf(ScriptSerializer.CATEGORY_SEPARATOR, StringComparison.Ordinal);
+      return index < 0 ? null : key.Substring(0, index);
+    }
+
+    /// <summary>
+    /// Lists the categories present in a registry, alphabetically, with <see cref="ALL"/> first.
+    /// </summary>
+    /// <param name="manipulators">The registry.</param>
+    /// <returns>The category names.</returns>
+    public static string[] List(KeyValuePair<string, IImageManipulator>[] manipulators) {
+      var categories = (manipulators ?? new KeyValuePair<string, IImageManipulator>[0])
+        .Select(pair => GetCategory(pair.Key))
+        .Where(category => category != null)
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .OrderBy(category => category, StringComparer.OrdinalIgnoreCase)
+        ;
+
+      return new[] { ALL }.Concat(categories).ToArray();
+    }
+
+    /// <summary>
+    /// Narrows a registry to one category.
+    /// </summary>
+    /// <param name="manipulators">The registry.</param>
+    /// <param name="category">The category, or <see cref="ALL"/>/<c>null</c> for everything.</param>
+    /// <returns>The entries in that category, in registry order.</returns>
+    public static KeyValuePair<string, IImageManipulator>[] Filter(KeyValuePair<string, IImageManipulator>[] manipulators, string category) {
+      if (manipulators == null)
+        return new KeyValuePair<string, IImageManipulator>[0];
+
+      if (category == null || category == ALL)
+        return manipulators;
+
+      return manipulators
+        .Where(pair => string.Equals(GetCategory(pair.Key), category, StringComparison.OrdinalIgnoreCase))
+        .ToArray()
+        ;
+    }
+
+    /// <summary>
+    /// Finds an entry's position in a list, so a category change can keep the current selection
+    /// rather than snapping the user back to the first method.
+    /// </summary>
+    /// <param name="manipulators">The list to search.</param>
+    /// <param name="manipulator">The manipulator to locate.</param>
+    /// <returns>Its index, or <c>-1</c> when the list does not contain it.</returns>
+    public static int IndexOf(KeyValuePair<string, IImageManipulator>[] manipulators, IImageManipulator manipulator) {
+      if (manipulators == null || manipulator == null)
+        return -1;
+
+      for (var i = 0; i < manipulators.Length; ++i)
+        if (ReferenceEquals(manipulators[i].Value, manipulator))
+          return i;
+
+      return -1;
+    }
+  }
+}

--- a/ImageResizer/MainForm.cs
+++ b/ImageResizer/MainForm.cs
@@ -71,6 +71,12 @@ namespace ImageResizer {
     // _SchedulePreview, which restarts the timer; 300 ms after the last change the timer
     // tick kicks off an async preview render into iwhTargetImage.
     private System.Windows.Forms.Timer _previewDebounce;
+
+    /// <summary>
+    /// Narrows <see cref="cmbResizeMethod"/> to one manipulator category. Created in code by
+    /// <see cref="_CreateCategoryFilter"/>.
+    /// </summary>
+    private ComboBox _cmbCategory;
     private CancellationTokenSource _previewCts;
 
     // The preview-owned bitmap currently shown in iwhTargetImage, if any. We OWN it and must
@@ -200,6 +206,8 @@ namespace ImageResizer {
 
       this.cmbResizeMethod.SelectedIndex = 0;
 
+      this._CreateCategoryFilter();
+
       this.cmbHorizontalBPH.DataSource = Enum.GetValues(typeof(OutOfBoundsMode));
       this.cmbVerticalBPH.DataSource = Enum.GetValues(typeof(OutOfBoundsMode));
 
@@ -259,6 +267,59 @@ namespace ImageResizer {
     }
 
     #endregion
+
+    /// <summary>
+    /// Adds the category selector above the method dropdown.
+    /// <para>
+    /// The registry holds several hundred methods, which is more than a single dropdown can
+    /// present usefully; picking a category narrows it to one kind of algorithm. Built in code
+    /// rather than in the Designer, the same way the Tools menu is, so the generated file stays
+    /// untouched.
+    /// </para>
+    /// </summary>
+    private void _CreateCategoryFilter() {
+      var group = this.cmbResizeMethod.Parent;
+      if (group == null)
+        return;
+
+      this._cmbCategory = new ComboBox {
+        Name = "cmbCategory",
+        DropDownStyle = ComboBoxStyle.DropDownList,
+        Location = this.cmbResizeMethod.Location,
+        Size = this.cmbResizeMethod.Size,
+        Anchor = this.cmbResizeMethod.Anchor,
+        TabIndex = this.cmbResizeMethod.TabIndex,
+      };
+
+      // make room: everything from the method dropdown down moves out of the way
+      var offset = this._cmbCategory.Height + 6;
+      foreach (Control control in group.Controls)
+        if (control.Top >= this.cmbResizeMethod.Top)
+          control.Top += offset;
+
+      group.Height += offset;
+      group.Controls.Add(this._cmbCategory);
+
+      this._cmbCategory.Items.AddRange(ManipulatorCategories.List(SupportedManipulators.MANIPULATORS));
+      this._cmbCategory.SelectedIndex = 0;
+      this._cmbCategory.SelectedIndexChanged += this._OnCategoryChanged;
+    }
+
+    /// <summary>
+    /// Narrows the method dropdown to the chosen category, keeping the current method selected
+    /// when it is still on offer.
+    /// </summary>
+    private void _OnCategoryChanged(object sender, EventArgs e) {
+      var previous = this.cmbResizeMethod.SelectedValue as IImageManipulator;
+      var methods = ManipulatorCategories.Filter(SupportedManipulators.MANIPULATORS, this._cmbCategory.SelectedItem as string);
+      if (methods.Length < 1)
+        return;
+
+      this.cmbResizeMethod.DataSource = methods;
+
+      var index = ManipulatorCategories.IndexOf(methods, previous);
+      this.cmbResizeMethod.SelectedIndex = index < 0 ? 0 : index;
+    }
 
     /// <summary>
     /// Loads and applies the configuration settings.

--- a/Tests/ImageResizer.Tests/ManipulatorCategoriesTests.cs
+++ b/Tests/ImageResizer.Tests/ManipulatorCategoriesTests.cs
@@ -1,0 +1,213 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Classes;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Covers the grouping behind the method dropdown's category selector. The dropdown itself is
+  /// two lines of wiring; the decisions live here where they can be checked.
+  /// </summary>
+  [TestFixture]
+  public class ManipulatorCategoriesTests {
+
+    private sealed class FakeManipulator : IImageManipulator {
+      public bool SupportsWidth => false;
+      public bool SupportsHeight => false;
+      public bool SupportsRepetitionCount => false;
+      public bool SupportsGridCentering => false;
+      public bool SupportsThresholds => false;
+      public bool SupportsRadius => false;
+      public bool ChangesResolution => false;
+      public string Description => "fake";
+      public IReadOnlyList<Hawkynt.ColorProcessing.ParameterDescriptor> Parameters => ImageManipulatorDefaults.EmptyParameters;
+      public IImageManipulator CreateWith(IReadOnlyDictionary<string, object> values) => this;
+    }
+
+    private static KeyValuePair<string, IImageManipulator> _Entry(string key)
+      => new KeyValuePair<string, IImageManipulator>(key, new FakeManipulator())
+    ;
+
+    private static KeyValuePair<string, IImageManipulator>[] _Registry()
+      => new[] {
+        _Entry("Filter: Blur"),
+        _Entry("Resampler: Bicubic"),
+        _Entry("Upscaler: HQ 2x"),
+        _Entry("Upscaler: XBR 3x"),
+      }
+    ;
+
+    #region category of a name
+
+    [TestCase("Upscaler: HQ 2x", "Upscaler")]
+    [TestCase("Resampler: Bicubic <GDI+>", "Resampler")]
+    [TestCase("Plane: Oklab L", "Plane")]
+    public void TheCategoryIsWhatPrecedesTheSeparator(string key, string expected)
+      => Assert.That(ManipulatorCategories.GetCategory(key), Is.EqualTo(expected))
+    ;
+
+    [TestCase("NoCategoryHere")]
+    [TestCase("")]
+    [TestCase(null)]
+    public void ANameWithoutASeparator_HasNoCategory(string key)
+      => Assert.That(ManipulatorCategories.GetCategory(key), Is.Null)
+    ;
+
+    [Test]
+    public void OnlyTheFirstSeparatorCounts()
+      => Assert.That(ManipulatorCategories.GetCategory("Filter: Channel: Red"), Is.EqualTo("Filter"))
+    ;
+
+    #endregion
+
+    #region listing
+
+    [Test]
+    public void TheListLeadsWithAll()
+      => Assert.That(ManipulatorCategories.List(_Registry()).First(), Is.EqualTo(ManipulatorCategories.ALL))
+    ;
+
+    [Test]
+    public void TheListIsDistinctAndAlphabetical()
+      => Assert.That(ManipulatorCategories.List(_Registry()), Is.EqualTo(new[] { ManipulatorCategories.ALL, "Filter", "Resampler", "Upscaler" }))
+    ;
+
+    [Test]
+    public void AnEmptyRegistry_StillOffersAll()
+      => Assert.That(ManipulatorCategories.List(new KeyValuePair<string, IImageManipulator>[0]), Is.EqualTo(new[] { ManipulatorCategories.ALL }))
+    ;
+
+    [Test]
+    public void ANullRegistry_StillOffersAll()
+      => Assert.That(ManipulatorCategories.List(null), Is.EqualTo(new[] { ManipulatorCategories.ALL }))
+    ;
+
+    [Test]
+    public void EntriesWithoutACategory_AreNotListed()
+      => Assert.That(ManipulatorCategories.List(new[] { _Entry("Loose"), _Entry("Filter: Blur") }), Is.EqualTo(new[] { ManipulatorCategories.ALL, "Filter" }))
+    ;
+
+    #endregion
+
+    #region filtering
+
+    [Test]
+    public void FilteringByACategory_KeepsOnlyItsEntries() {
+      var result = ManipulatorCategories.Filter(_Registry(), "Upscaler");
+
+      Assert.That(result.Select(pair => pair.Key), Is.EqualTo(new[] { "Upscaler: HQ 2x", "Upscaler: XBR 3x" }));
+    }
+
+    [Test]
+    public void FilteringByAll_KeepsEverything()
+      => Assert.That(ManipulatorCategories.Filter(_Registry(), ManipulatorCategories.ALL).Length, Is.EqualTo(4))
+    ;
+
+    [Test]
+    public void FilteringByNull_KeepsEverything()
+      => Assert.That(ManipulatorCategories.Filter(_Registry(), null).Length, Is.EqualTo(4))
+    ;
+
+    [Test]
+    public void FilteringIsCaseInsensitive()
+      => Assert.That(ManipulatorCategories.Filter(_Registry(), "upSCALer").Length, Is.EqualTo(2))
+    ;
+
+    [Test]
+    public void FilteringByAnAbsentCategory_KeepsNothing()
+      => Assert.That(ManipulatorCategories.Filter(_Registry(), "Downscaler"), Is.Empty)
+    ;
+
+    [Test]
+    public void FilteringPreservesRegistryOrder() {
+      var result = ManipulatorCategories.Filter(_Registry(), ManipulatorCategories.ALL);
+
+      Assert.That(result.Select(pair => pair.Key), Is.EqualTo(_Registry().Select(pair => pair.Key)));
+    }
+
+    #endregion
+
+    #region keeping the selection
+
+    [Test]
+    public void TheCurrentMethod_IsFoundInANarrowedList() {
+      var registry = _Registry();
+      var wanted = registry[3].Value;
+
+      var narrowed = ManipulatorCategories.Filter(registry, "Upscaler");
+
+      Assert.That(ManipulatorCategories.IndexOf(narrowed, wanted), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void AMethodOutsideTheNarrowedList_IsNotFound() {
+      var registry = _Registry();
+
+      var narrowed = ManipulatorCategories.Filter(registry, "Upscaler");
+
+      Assert.That(ManipulatorCategories.IndexOf(narrowed, registry[0].Value), Is.EqualTo(-1));
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void LocatingNothing_IsNotFound(bool nullList) {
+      var registry = nullList ? null : _Registry();
+      var manipulator = nullList ? new FakeManipulator() : null;
+
+      Assert.That(ManipulatorCategories.IndexOf(registry, manipulator), Is.EqualTo(-1));
+    }
+
+    #endregion
+
+    #region against the real registry
+
+    [Test]
+    public void EveryRealCategoryOffersAtLeastOneMethod() {
+      var categories = ManipulatorCategories.List(SupportedManipulators.MANIPULATORS).Skip(1);
+
+      foreach (var category in categories)
+        Assert.That(ManipulatorCategories.Filter(SupportedManipulators.MANIPULATORS, category), Is.Not.Empty, category);
+    }
+
+    [Test]
+    public void TheCategoriesPartitionTheRegistry() {
+      var categories = ManipulatorCategories.List(SupportedManipulators.MANIPULATORS).Skip(1);
+      var total = categories.Sum(category => ManipulatorCategories.Filter(SupportedManipulators.MANIPULATORS, category).Length);
+
+      Assert.That(total, Is.EqualTo(SupportedManipulators.MANIPULATORS.Length), "every entry belongs to exactly one category");
+    }
+
+    [Test]
+    public void NarrowingTheRealRegistry_IsAlwaysSmallerThanAll() {
+      var upscalers = ManipulatorCategories.Filter(SupportedManipulators.MANIPULATORS, "Upscaler");
+
+      Assert.That(upscalers.Length, Is.GreaterThan(0));
+      Assert.That(upscalers.Length, Is.LessThan(SupportedManipulators.MANIPULATORS.Length));
+    }
+
+    #endregion
+
+  }
+}


### PR DESCRIPTION
Closes #3.

The dropdown listed every registered method at once — several hundred entries with no structure, which the report describes as leaving an average user with no idea what any of them are.

A selector above it narrows the list to one category (`Upscaler`, `Resampler`, `Filter`, `Plane`, …), with `(all)` to go back. The current method stays selected whenever the new category still offers it, rather than snapping back to the first entry.

Categories come from the registry itself, so a new one appears as soon as something is registered under it — nothing to keep in sync by hand.

## Where the logic lives

The grouping is in `ManipulatorCategories` so it can be tested; the form is three lines of wiring. **25 new tests** cover the category of a name, listing, filtering, keeping the selection across a change, and four properties of the real registry — including that the categories partition it exactly.

The control is built in code rather than in the Designer, the same way the Tools menu already is.

## Verification

Launched the built application and confirmed the selector renders and the layout below it shifts correctly; restoring a saved `Upscaler` category selects `Upscaler: HQ 2x` and updates the description pane.

**555 tests green.**