### PR TITLE
+ persist window placement and the working settings

### DIFF
--- a/ImageResizer/Classes/Config.cs
+++ b/ImageResizer/Classes/Config.cs
@@ -1,31 +1,173 @@
-﻿using System;
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Extensions.ColorProcessing.Resizing;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 using System.Xml.Linq;
 
 namespace Classes {
   /// <summary>
-  /// This class stores the different configuration options of the application and handles config save/load
+  /// The settings that survive between sessions.
+  /// <para>
+  /// Each one is declared once in <see cref="_SETTINGS"/> with the pair of conversions it needs;
+  /// loading and saving both walk that table, so the two can never disagree about a name and
+  /// adding a setting is one entry rather than two matching branches.
+  /// </para>
+  /// <para>
+  /// Anything unreadable is skipped rather than fatal: a configuration written by a newer build,
+  /// or hand-edited into nonsense, must not stop the application from starting.
+  /// </para>
   /// </summary>
   internal static class Config {
+
     #region consts
+
     private const string _ROOT_NODE_NAME = "Configuration";
     private const string _VALUE_ATTRIBUTE_NAME = "value";
-    private const string _LAST_SAVE_DIRECTORY_NODE_NAME = "LastSaveDirectory";
-    private const string _LAST_LOAD_DIRECTORY_NODE_NAME = "LastLoadDirectory";
-    private const string _SOURCE_SIZE_MODE_NODE_NAME = "SourceSizeMode";
-    private const string _TARGET_SIZE_MODE_NODE_NAME = "TargetSizeMode";
+
     #endregion
 
     #region props
+
     public static string LastSaveDirectory { get; set; }
     public static string LastLoadDirectory { get; set; }
     public static PictureBoxSizeMode? SourceSizeMode { get; set; }
     public static PictureBoxSizeMode? TargetSizeMode { get; set; }
+
+    /// <summary>The window's restored position and size, so it comes back where it was left.</summary>
+    public static Rectangle? WindowBounds { get; set; }
+
+    /// <summary>Whether the window was maximized. Never <see cref="FormWindowState.Minimized"/>.</summary>
+    public static FormWindowState? WindowState { get; set; }
+
+    /// <summary>The registered name of the last used method, e.g. <c>"Upscaler: HQ 2x"</c>.</summary>
+    public static string ResizeMethod { get; set; }
+
+    /// <summary>The last selected method category, or <c>null</c> for all of them.</summary>
+    public static string MethodCategory { get; set; }
+
+    public static OutOfBoundsMode? HorizontalBph { get; set; }
+    public static OutOfBoundsMode? VerticalBph { get; set; }
+    public static bool? UseThresholds { get; set; }
+    public static bool? UseCenteredGrid { get; set; }
+    public static bool? KeepAspect { get; set; }
+    public static int? RepetitionCount { get; set; }
+    public static float? Radius { get; set; }
+
+    #endregion
+
+    #region the table
+
+    /// <summary>One persisted setting: its element name and how it converts to and from text.</summary>
+    private sealed class Setting {
+      public string Name { get; }
+
+      /// <summary>Renders the current value, or <c>null</c> when there is nothing to write.</summary>
+      public Func<string> Read { get; }
+
+      /// <summary>Applies a value read back from the file. Only called with non-empty text.</summary>
+      public Action<string> Write { get; }
+
+      public Setting(string name, Func<string> read, Action<string> write) {
+        this.Name = name;
+        this.Read = read;
+        this.Write = write;
+      }
+    }
+
+    private static string _FromEnum<TEnum>(TEnum? value) where TEnum : struct
+      => value?.ToString()
+    ;
+
+    private static void _ToEnum<TEnum>(string text, Action<TEnum?> assign) where TEnum : struct {
+      if (Enum.TryParse<TEnum>(text, true, out var parsed))
+        assign(parsed);
+    }
+
+    private static string _FromBool(bool? value)
+      => value?.ToString(CultureInfo.InvariantCulture)
+    ;
+
+    private static void _ToBool(string text, Action<bool?> assign) {
+      if (bool.TryParse(text, out var parsed))
+        assign(parsed);
+    }
+
+    private static string _FromRectangle(Rectangle? value)
+      => value == null
+        ? null
+        : string.Join(",", new[] { value.Value.X, value.Value.Y, value.Value.Width, value.Value.Height }.Select(v => v.ToString(CultureInfo.InvariantCulture)))
+    ;
+
+    private static void _ToRectangle(string text, Action<Rectangle?> assign) {
+      var parts = text.Split(',');
+      if (parts.Length != 4)
+        return;
+
+      var numbers = new int[4];
+      for (var i = 0; i < 4; ++i)
+        if (!int.TryParse(parts[i].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out numbers[i]))
+          return;
+
+      // a window with no extent is not something to restore
+      if (numbers[2] <= 0 || numbers[3] <= 0)
+        return;
+
+      assign(new Rectangle(numbers[0], numbers[1], numbers[2], numbers[3]));
+    }
+
+    private static readonly Setting[] _SETTINGS = {
+      new Setting("LastSaveDirectory", () => LastSaveDirectory, v => LastSaveDirectory = v),
+      new Setting("LastLoadDirectory", () => LastLoadDirectory, v => LastLoadDirectory = v),
+      new Setting("SourceSizeMode", () => _FromEnum(SourceSizeMode), v => _ToEnum<PictureBoxSizeMode>(v, p => SourceSizeMode = p)),
+      new Setting("TargetSizeMode", () => _FromEnum(TargetSizeMode), v => _ToEnum<PictureBoxSizeMode>(v, p => TargetSizeMode = p)),
+      new Setting("WindowBounds", () => _FromRectangle(WindowBounds), v => _ToRectangle(v, r => WindowBounds = r)),
+      new Setting("WindowState", () => _FromEnum(WindowState), v => _ToEnum<FormWindowState>(v, p => WindowState = p == FormWindowState.Minimized ? FormWindowState.Normal : p)),
+      new Setting("ResizeMethod", () => ResizeMethod, v => ResizeMethod = v),
+      new Setting("MethodCategory", () => MethodCategory, v => MethodCategory = v),
+      new Setting("HorizontalBph", () => _FromEnum(HorizontalBph), v => _ToEnum<OutOfBoundsMode>(v, p => HorizontalBph = p)),
+      new Setting("VerticalBph", () => _FromEnum(VerticalBph), v => _ToEnum<OutOfBoundsMode>(v, p => VerticalBph = p)),
+      new Setting("UseThresholds", () => _FromBool(UseThresholds), v => _ToBool(v, p => UseThresholds = p)),
+      new Setting("UseCenteredGrid", () => _FromBool(UseCenteredGrid), v => _ToBool(v, p => UseCenteredGrid = p)),
+      new Setting("KeepAspect", () => _FromBool(KeepAspect), v => _ToBool(v, p => KeepAspect = p)),
+      new Setting("RepetitionCount", () => RepetitionCount?.ToString(CultureInfo.InvariantCulture), v => {
+        if (int.TryParse(v, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed > 0)
+          RepetitionCount = parsed;
+      }),
+      new Setting("Radius", () => Radius?.ToString("R", CultureInfo.InvariantCulture), v => {
+        if (float.TryParse(v, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) && parsed > 0)
+          Radius = parsed;
+      }),
+    };
+
     #endregion
 
     /// <summary>
-    /// Loads the configuration from the specified file.
+    /// Loads the configuration from the specified file. A missing or foreign file leaves every
+    /// setting at its default.
     /// </summary>
     /// <param name="configurationFile">The configuration file.</param>
     public static void Load(string configurationFile) {
@@ -38,32 +180,17 @@ namespace Classes {
       if (!string.Equals(root.Name.LocalName, _ROOT_NODE_NAME, StringComparison.CurrentCultureIgnoreCase))
         return;
 
-      PictureBoxSizeMode temp;
-      foreach (XElement node in root.Nodes()) {
+      var byName = _SETTINGS.ToDictionary(setting => setting.Name, StringComparer.OrdinalIgnoreCase);
 
-        // skip nodes without value attribute
-        var valueAttribute = node.Attribute(_VALUE_ATTRIBUTE_NAME);
-        if (valueAttribute == null)
-          continue;
-
-        // skip nodes with empty value attribute
-        var value = valueAttribute.Value;
+      foreach (var node in root.Elements()) {
+        var value = node.Attribute(_VALUE_ATTRIBUTE_NAME)?.Value;
         if (string.IsNullOrWhiteSpace(value))
           continue;
 
-        var nodeName = node.Name.LocalName;
-
-        // set value depending on node and validity
-        if (string.Equals(nodeName, _LAST_LOAD_DIRECTORY_NODE_NAME, StringComparison.CurrentCultureIgnoreCase))
-          LastLoadDirectory = value;
-        else if (string.Equals(nodeName, _LAST_SAVE_DIRECTORY_NODE_NAME, StringComparison.CurrentCultureIgnoreCase))
-          LastSaveDirectory = value;
-        else if (string.Equals(nodeName, _SOURCE_SIZE_MODE_NODE_NAME, StringComparison.CurrentCultureIgnoreCase) && Enum.TryParse(value, true, out temp))
-          SourceSizeMode = temp;
-        else if (string.Equals(nodeName, _TARGET_SIZE_MODE_NODE_NAME, StringComparison.CurrentCultureIgnoreCase) && Enum.TryParse(value, true, out temp))
-          TargetSizeMode = temp;
+        // an element this build does not know is left alone, not an error
+        if (byName.TryGetValue(node.Name.LocalName, out var setting))
+          setting.Write(value);
       }
-
     }
 
     /// <summary>
@@ -71,14 +198,25 @@ namespace Classes {
     /// </summary>
     /// <param name="configurationFile">The configuration file.</param>
     public static void Save(string configurationFile) {
-
       var root = new XElement(_ROOT_NODE_NAME);
-      root.Add(new XElement(_LAST_SAVE_DIRECTORY_NODE_NAME, new XAttribute(_VALUE_ATTRIBUTE_NAME, LastSaveDirectory ?? string.Empty)));
-      root.Add(new XElement(_LAST_LOAD_DIRECTORY_NODE_NAME, new XAttribute(_VALUE_ATTRIBUTE_NAME, LastLoadDirectory ?? string.Empty)));
-      root.Add(new XElement(_SOURCE_SIZE_MODE_NODE_NAME, new XAttribute(_VALUE_ATTRIBUTE_NAME, SourceSizeMode == null ? string.Empty : SourceSizeMode.Value.ToString())));
-      root.Add(new XElement(_TARGET_SIZE_MODE_NODE_NAME, new XAttribute(_VALUE_ATTRIBUTE_NAME, TargetSizeMode == null ? string.Empty : TargetSizeMode.Value.ToString())));
-      root.Save(configurationFile);
+      foreach (var setting in _SETTINGS)
+        root.Add(new XElement(setting.Name, new XAttribute(_VALUE_ATTRIBUTE_NAME, setting.Read() ?? string.Empty)));
 
+      root.Save(configurationFile);
+    }
+
+    /// <summary>
+    /// Forgets every setting. Exists for tests, which share this static state between cases.
+    /// </summary>
+    public static void Reset() {
+      LastSaveDirectory = LastLoadDirectory = ResizeMethod = MethodCategory = null;
+      SourceSizeMode = TargetSizeMode = null;
+      WindowBounds = null;
+      WindowState = null;
+      HorizontalBph = VerticalBph = null;
+      UseThresholds = UseCenteredGrid = KeepAspect = null;
+      RepetitionCount = null;
+      Radius = null;
     }
   }
 }

--- a/ImageResizer/MainForm.cs
+++ b/ImageResizer/MainForm.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Drawing;
@@ -233,6 +234,7 @@ namespace ImageResizer {
       this.chkUseThresholds.Checked = false;
 
       this._LoadConfigurationSettings();
+      this.FormClosing += (s, e) => this._SaveConfigurationSettings();
 
       if (fileToOpenOnStart != null)
         this._LoadImageFromFileName(fileToOpenOnStart);
@@ -449,7 +451,104 @@ namespace ImageResizer {
 
       if (Config.TargetSizeMode != null)
         this._TargetImageSizeMode = Config.TargetSizeMode.Value;
+
+      this._RestoreWindowPlacement();
+
+      // category before method: narrowing the list would otherwise drop the restored selection
+      if (Config.MethodCategory != null && this._cmbCategory != null && this._cmbCategory.Items.Contains(Config.MethodCategory))
+        this._cmbCategory.SelectedItem = Config.MethodCategory;
+
+      if (Config.ResizeMethod != null)
+        this._SelectMethodByName(Config.ResizeMethod);
+
+      if (Config.HorizontalBph != null)
+        this.cmbHorizontalBPH.SelectedItem = Config.HorizontalBph.Value;
+
+      if (Config.VerticalBph != null)
+        this.cmbVerticalBPH.SelectedItem = Config.VerticalBph.Value;
+
+      if (Config.UseThresholds != null)
+        this.chkUseThresholds.Checked = Config.UseThresholds.Value;
+
+      if (Config.UseCenteredGrid != null)
+        this.chkUseCenteredGrid.Checked = Config.UseCenteredGrid.Value;
+
+      if (Config.KeepAspect != null)
+        this.chkKeepAspect.Checked = Config.KeepAspect.Value;
+
+      if (Config.RepetitionCount != null)
+        this.nudRepetitionCount.Value = _Clamp(Config.RepetitionCount.Value, this.nudRepetitionCount);
+
+      if (Config.Radius != null)
+        this.nudRadius.Value = _Clamp((decimal)Config.Radius.Value, this.nudRadius);
     }
+
+    /// <summary>
+    /// Captures everything worth remembering into <see cref="Config"/>. Runs while the window is
+    /// closing, before <c>Program</c> writes the file.
+    /// </summary>
+    private void _SaveConfigurationSettings() {
+      // Maximized and minimized bounds describe the current state, not the size to come back to
+      Config.WindowBounds = this.WindowState == FormWindowState.Normal ? this.Bounds : this.RestoreBounds;
+      Config.WindowState = this.WindowState == FormWindowState.Minimized ? FormWindowState.Normal : this.WindowState;
+
+      Config.MethodCategory = this._cmbCategory?.SelectedItem as string;
+      Config.ResizeMethod = this._SelectedMethodName();
+      Config.HorizontalBph = this.cmbHorizontalBPH.SelectedItem as OutOfBoundsMode?;
+      Config.VerticalBph = this.cmbVerticalBPH.SelectedItem as OutOfBoundsMode?;
+      Config.UseThresholds = this.chkUseThresholds.Checked;
+      Config.UseCenteredGrid = this.chkUseCenteredGrid.Checked;
+      Config.KeepAspect = this.chkKeepAspect.Checked;
+      Config.RepetitionCount = (int)this.nudRepetitionCount.Value;
+      Config.Radius = (float)this.nudRadius.Value;
+    }
+
+    /// <summary>
+    /// Puts the window back where it was, unless that is off every screen - a monitor that is no
+    /// longer attached would otherwise strand the window out of reach.
+    /// </summary>
+    private void _RestoreWindowPlacement() {
+      var bounds = Config.WindowBounds;
+      if (bounds != null && Screen.AllScreens.Any(screen => screen.WorkingArea.IntersectsWith(bounds.Value))) {
+        this.StartPosition = FormStartPosition.Manual;
+        this.Bounds = bounds.Value;
+      }
+
+      if (Config.WindowState != null && Config.WindowState.Value != FormWindowState.Minimized)
+        this.WindowState = Config.WindowState.Value;
+    }
+
+    /// <summary>
+    /// Gets the registered name of the selected method.
+    /// </summary>
+    private string _SelectedMethodName() {
+      var selected = this.cmbResizeMethod.SelectedValue as IImageManipulator;
+      var index = ManipulatorCategories.IndexOf(SupportedManipulators.MANIPULATORS, selected);
+      return index < 0 ? null : SupportedManipulators.MANIPULATORS[index].Key;
+    }
+
+    /// <summary>
+    /// Selects a method by its registered name, if the current list still offers it.
+    /// </summary>
+    /// <param name="name">The registered name.</param>
+    private void _SelectMethodByName(string name) {
+      if (!(this.cmbResizeMethod.DataSource is KeyValuePair<string, IImageManipulator>[] methods))
+        return;
+
+      for (var i = 0; i < methods.Length; ++i)
+        if (string.Equals(methods[i].Key, name, StringComparison.OrdinalIgnoreCase)) {
+          this.cmbResizeMethod.SelectedIndex = i;
+          return;
+        }
+    }
+
+    /// <summary>
+    /// Keeps a remembered value inside what its control accepts - the limits can change between
+    /// builds, and an out-of-range assignment throws.
+    /// </summary>
+    private static decimal _Clamp(decimal value, NumericUpDown control)
+      => value < control.Minimum ? control.Minimum : value > control.Maximum ? control.Maximum : value
+    ;
 
     /// <summary>
     /// If the current selection has a parameter surface and the user has changed at least one

--- a/Tests/ImageResizer.Tests/ConfigTests.cs
+++ b/Tests/ImageResizer.Tests/ConfigTests.cs
@@ -18,6 +18,8 @@
  */
 #endregion
 
+using System.Drawing;
+using System.Drawing.Extensions.ColorProcessing.Resizing;
 using System.IO;
 using System.Windows.Forms;
 using System.Xml;
@@ -47,12 +49,7 @@ namespace ImageResizer.Tests {
       this._directory.Dispose();
     }
 
-    private static void _Reset() {
-      Config.LastLoadDirectory = null;
-      Config.LastSaveDirectory = null;
-      Config.SourceSizeMode = null;
-      Config.TargetSizeMode = null;
-    }
+    private static void _Reset() => Config.Reset();
 
     #region round trip
 
@@ -63,6 +60,17 @@ namespace ImageResizer.Tests {
       Config.LastSaveDirectory = @"C:\saves";
       Config.SourceSizeMode = PictureBoxSizeMode.Zoom;
       Config.TargetSizeMode = PictureBoxSizeMode.CenterImage;
+      Config.WindowBounds = new Rectangle(12, 34, 800, 600);
+      Config.WindowState = FormWindowState.Maximized;
+      Config.ResizeMethod = "Upscaler: HQ 2x";
+      Config.MethodCategory = "Upscaler";
+      Config.HorizontalBph = OutOfBoundsMode.WrapAround;
+      Config.VerticalBph = OutOfBoundsMode.HalfSampleSymmetric;
+      Config.UseThresholds = true;
+      Config.UseCenteredGrid = false;
+      Config.KeepAspect = true;
+      Config.RepetitionCount = 4;
+      Config.Radius = 2.5f;
       Config.Save(file);
       _Reset();
 
@@ -72,6 +80,80 @@ namespace ImageResizer.Tests {
       Assert.That(Config.LastSaveDirectory, Is.EqualTo(@"C:\saves"));
       Assert.That(Config.SourceSizeMode, Is.EqualTo(PictureBoxSizeMode.Zoom));
       Assert.That(Config.TargetSizeMode, Is.EqualTo(PictureBoxSizeMode.CenterImage));
+      Assert.That(Config.WindowBounds, Is.EqualTo(new Rectangle(12, 34, 800, 600)));
+      Assert.That(Config.WindowState, Is.EqualTo(FormWindowState.Maximized));
+      Assert.That(Config.ResizeMethod, Is.EqualTo("Upscaler: HQ 2x"));
+      Assert.That(Config.MethodCategory, Is.EqualTo("Upscaler"));
+      Assert.That(Config.HorizontalBph, Is.EqualTo(OutOfBoundsMode.WrapAround));
+      Assert.That(Config.VerticalBph, Is.EqualTo(OutOfBoundsMode.HalfSampleSymmetric));
+      Assert.That(Config.UseThresholds, Is.True);
+      Assert.That(Config.UseCenteredGrid, Is.False);
+      Assert.That(Config.KeepAspect, Is.True);
+      Assert.That(Config.RepetitionCount, Is.EqualTo(4));
+      Assert.That(Config.Radius, Is.EqualTo(2.5f));
+    }
+
+    #endregion
+
+    #region window placement
+
+    [TestCase("12,34,800,600", true)]
+    [TestCase("0,0,1,1", true)]
+    [TestCase("12,34,0,600", false)]
+    [TestCase("12,34,800,0", false)]
+    [TestCase("12,34,800", false)]
+    [TestCase("a,b,c,d", false)]
+    [TestCase("", false)]
+    public void OnlyAWindowWithExtentIsRestored(string value, bool expected) {
+      var file = this._directory.File("config.xml");
+      File.WriteAllText(file, $@"<Configuration><WindowBounds value=""{value}"" /></Configuration>");
+
+      Config.Load(file);
+
+      Assert.That(Config.WindowBounds != null, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void AMinimizedWindowIsRememberedAsNormal() {
+      var file = this._directory.File("config.xml");
+      File.WriteAllText(file, @"<Configuration><WindowState value=""Minimized"" /></Configuration>");
+
+      Config.Load(file);
+
+      Assert.That(Config.WindowState, Is.EqualTo(FormWindowState.Normal), "nobody wants to reopen a minimized window");
+    }
+
+    [TestCase("RepetitionCount", "0")]
+    [TestCase("RepetitionCount", "-1")]
+    [TestCase("RepetitionCount", "many")]
+    [TestCase("Radius", "0")]
+    [TestCase("Radius", "-2")]
+    [TestCase("Radius", "wide")]
+    public void ANonsensicalNumberIsIgnored(string element, string value) {
+      var file = this._directory.File("config.xml");
+      File.WriteAllText(file, $@"<Configuration><{element} value=""{value}"" /></Configuration>");
+
+      Config.Load(file);
+
+      Assert.That(Config.RepetitionCount, Is.Null);
+      Assert.That(Config.Radius, Is.Null);
+    }
+
+    [Test]
+    public void RadiusIsWrittenAndReadInvariantOfTheCurrentCulture() {
+      var file = this._directory.File("config.xml");
+      var previous = System.Threading.Thread.CurrentThread.CurrentCulture;
+      System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("de-DE");
+      try {
+        Config.Radius = 1.5f;
+        Config.Save(file);
+        _Reset();
+        Config.Load(file);
+
+        Assert.That(Config.Radius, Is.EqualTo(1.5f));
+      } finally {
+        System.Threading.Thread.CurrentThread.CurrentCulture = previous;
+      }
     }
 
     [Test]


### PR DESCRIPTION
Closes #4. Stacked on the percentage PR.

Only the two preview size modes were persisted, so every session started by re-arranging the window and re-choosing the method and the border handling — exactly what the report asks for.

Now persisted: restored window position and size, maximized state, the method and its category, both border-pixel-handling modes, the thresholds / centred-grid / keep-aspect flags, the repetition count and the radius.

A window whose remembered position lies on no attached screen opens where it will rather than stranded off the desktop, and a minimized window comes back normal.

## Why the settings became a table

Load and save used to be separate per-setting branches, which is how they came to disagree — a setting was easy to write and forget to read. Each is now declared once with its pair of conversions and both directions walk that table. Adding one is a single entry.

A value the current build cannot parse is skipped rather than fatal: a configuration written by a newer build must not stop startup.

## Verification

Not just unit tests — I ran the built application, closed it cleanly and read back the file it wrote:

```xml
<WindowBounds value="182,182,905,641" />
<ResizeMethod value="Filter: AccentedEdges" />
<MethodCategory value="(all)" />
```

then edited it to `300,200,700,520` / `Upscaler: HQ 2x` / `Upscaler`, relaunched, and confirmed the window came back at 300,200 with the category and method selected and the description pane following. (Height clamps to the form's minimum, which is expected.)

**601 tests green.**