### PR TITLE
+ associate .irs scripts with the executable

### DIFF
--- a/ImageResizer/Classes/ScriptFileAssociation.cs
+++ b/ImageResizer/Classes/ScriptFileAssociation.cs
@@ -1,0 +1,142 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32;
+
+namespace Classes {
+  /// <summary>
+  /// Registers <c>.irs</c> scripts with this executable, so double clicking one runs it.
+  /// <para>
+  /// Everything is written under <c>HKEY_CURRENT_USER\Software\Classes</c>, which needs no
+  /// elevation and affects only the current user. The registry root is a parameter so this can be
+  /// exercised against a scratch key instead of the user's real associations.
+  /// </para>
+  /// </summary>
+  internal static class ScriptFileAssociation {
+
+    /// <summary>The identifier the extension points at.</summary>
+    public const string PROGRAM_IDENTIFIER = "ImageResizer.Script";
+
+    /// <summary>What Explorer shows as the file type.</summary>
+    public const string FILE_TYPE_DESCRIPTION = "ImageResizer Script";
+
+    private const string _USER_CLASSES = @"Software\Classes";
+    private const string _COMMAND_PATH = PROGRAM_IDENTIFIER + @"\shell\open\command";
+    private const string _ICON_PATH = PROGRAM_IDENTIFIER + @"\DefaultIcon";
+
+    #region shell notification
+
+    private const int _SHCNE_ASSOCCHANGED = 0x08000000;
+    private const int _SHCNF_IDLIST = 0x0000;
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern void SHChangeNotify(int eventId, int flags, IntPtr item1, IntPtr item2);
+
+    /// <summary>
+    /// Tells Explorer the associations changed, so the new icon and verb appear without a logoff.
+    /// </summary>
+    public static void NotifyShell() {
+      try {
+        SHChangeNotify(_SHCNE_ASSOCCHANGED, _SHCNF_IDLIST, IntPtr.Zero, IntPtr.Zero);
+      } catch (Exception) {
+        // cosmetic only - the association itself is already written
+      }
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Opens the per-user class registrations.
+    /// </summary>
+    /// <returns>The key; the caller disposes it.</returns>
+    public static RegistryKey OpenUserClasses() => Registry.CurrentUser.CreateSubKey(_USER_CLASSES);
+
+    /// <summary>
+    /// The command line Explorer runs for a script.
+    /// </summary>
+    /// <param name="executablePath">The executable.</param>
+    /// <returns>The command, with the quoted file placeholder.</returns>
+    public static string BuildCommand(string executablePath) => "\"" + executablePath + "\" \"%1\"";
+
+    /// <summary>
+    /// Determines whether scripts are currently associated with an executable.
+    /// </summary>
+    /// <param name="classesRoot">The class registrations to look in.</param>
+    /// <param name="executablePath">The executable to check for.</param>
+    /// <returns><c>true</c> when the extension resolves to this executable.</returns>
+    public static bool IsRegistered(RegistryKey classesRoot, string executablePath) {
+      if (classesRoot == null || string.IsNullOrWhiteSpace(executablePath))
+        return false;
+
+      using (var extension = classesRoot.OpenSubKey(ScriptSerializer.DEFAULT_FILE_EXTENSION)) {
+        if (!string.Equals(extension?.GetValue(null) as string, PROGRAM_IDENTIFIER, StringComparison.OrdinalIgnoreCase))
+          return false;
+      }
+
+      using (var command = classesRoot.OpenSubKey(_COMMAND_PATH))
+        return string.Equals(command?.GetValue(null) as string, BuildCommand(executablePath), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Associates scripts with an executable.
+    /// </summary>
+    /// <param name="classesRoot">The class registrations to write to.</param>
+    /// <param name="executablePath">The executable to point at.</param>
+    public static void Register(RegistryKey classesRoot, string executablePath) {
+      if (classesRoot == null || string.IsNullOrWhiteSpace(executablePath))
+        return;
+
+      using (var extension = classesRoot.CreateSubKey(ScriptSerializer.DEFAULT_FILE_EXTENSION))
+        extension?.SetValue(null, PROGRAM_IDENTIFIER);
+
+      using (var program = classesRoot.CreateSubKey(PROGRAM_IDENTIFIER))
+        program?.SetValue(null, FILE_TYPE_DESCRIPTION);
+
+      using (var icon = classesRoot.CreateSubKey(_ICON_PATH))
+        icon?.SetValue(null, executablePath + ",0");
+
+      using (var command = classesRoot.CreateSubKey(_COMMAND_PATH))
+        command?.SetValue(null, BuildCommand(executablePath));
+    }
+
+    /// <summary>
+    /// Removes the association.
+    /// <para>
+    /// Only the extension entry this code owns is removed, and only when it still points at our
+    /// identifier - another program may have taken the extension over since, and stealing it back
+    /// on the way out would be worse than leaving it.
+    /// </para>
+    /// </summary>
+    /// <param name="classesRoot">The class registrations to clean.</param>
+    public static void Unregister(RegistryKey classesRoot) {
+      if (classesRoot == null)
+        return;
+
+      using (var extension = classesRoot.OpenSubKey(ScriptSerializer.DEFAULT_FILE_EXTENSION))
+        if (string.Equals(extension?.GetValue(null) as string, PROGRAM_IDENTIFIER, StringComparison.OrdinalIgnoreCase))
+          classesRoot.DeleteSubKeyTree(ScriptSerializer.DEFAULT_FILE_EXTENSION, false);
+
+      classesRoot.DeleteSubKeyTree(PROGRAM_IDENTIFIER, false);
+    }
+  }
+}

--- a/ImageResizer/MainForm.cs
+++ b/ImageResizer/MainForm.cs
@@ -90,6 +90,11 @@ namespace ImageResizer {
     /// loop while one is being updated from the other.
     /// </summary>
     private bool _isApplyingPercentage;
+
+    /// <summary>
+    /// Toggles the <c>.irs</c> file association. Checked while scripts open with this build.
+    /// </summary>
+    private ToolStripMenuItem _associateScriptsItem;
     private CancellationTokenSource _previewCts;
 
     // The preview-owned bitmap currently shown in iwhTargetImage, if any. We OWN it and must
@@ -245,6 +250,10 @@ namespace ImageResizer {
       var toolsMenu = new ToolStripMenuItem("&Tools");
       var reduceColorsItem = new ToolStripMenuItem("&Reduce Colours…", null, this._OnReduceColoursClicked);
       toolsMenu.DropDownItems.Add(reduceColorsItem);
+      toolsMenu.DropDownItems.Add(new ToolStripSeparator());
+      this._associateScriptsItem = new ToolStripMenuItem("&Associate " + ScriptSerializer.DEFAULT_FILE_EXTENSION + " scripts", null, this._OnAssociateScriptsClicked);
+      toolsMenu.DropDownItems.Add(this._associateScriptsItem);
+      toolsMenu.DropDownOpening += (s, e) => this._RefreshScriptAssociationState();
       var helpIndex = this.msMain.Items.IndexOf(this.helpToolStripMenuItem);
       if (helpIndex >= 0)
         this.msMain.Items.Insert(helpIndex, toolsMenu);
@@ -439,6 +448,44 @@ namespace ImageResizer {
         this._nudPercentage.Value = decimal.Round(percentage, 0);
       } finally {
         this._isApplyingPercentage = false;
+      }
+    }
+
+    /// <summary>
+    /// Ticks the menu item when scripts currently open with this build.
+    /// </summary>
+    private void _RefreshScriptAssociationState() {
+      try {
+        using (var classes = ScriptFileAssociation.OpenUserClasses())
+          this._associateScriptsItem.Checked = ScriptFileAssociation.IsRegistered(classes, Application.ExecutablePath);
+      } catch (Exception) {
+        // a registry we cannot read just means we cannot show the state
+        this._associateScriptsItem.Checked = false;
+      }
+    }
+
+    /// <summary>
+    /// Associates or disassociates <c>.irs</c> scripts with this build.
+    /// </summary>
+    private void _OnAssociateScriptsClicked(object sender, EventArgs e) {
+      try {
+        using (var classes = ScriptFileAssociation.OpenUserClasses()) {
+          var executable = Application.ExecutablePath;
+          if (ScriptFileAssociation.IsRegistered(classes, executable))
+            ScriptFileAssociation.Unregister(classes);
+          else
+            ScriptFileAssociation.Register(classes, executable);
+        }
+
+        ScriptFileAssociation.NotifyShell();
+        this._RefreshScriptAssociationState();
+      } catch (Exception exception) {
+        MessageBox.Show(
+          "The file association could not be changed." + Environment.NewLine + exception.Message,
+          "Associate scripts",
+          MessageBoxButtons.OK,
+          MessageBoxIcon.Warning
+        );
       }
     }
 

--- a/Tests/ImageResizer.Tests/ScriptFileAssociationTests.cs
+++ b/Tests/ImageResizer.Tests/ScriptFileAssociationTests.cs
@@ -1,0 +1,210 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+
+using Classes;
+
+using Microsoft.Win32;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Covers the <c>.irs</c> file association. Everything runs against a scratch key created for
+  /// the test and deleted afterwards - the user's real associations are never touched.
+  /// </summary>
+  [TestFixture]
+  public class ScriptFileAssociationTests {
+
+    private const string _EXECUTABLE = @"C:\Program Files\ImageResizer\ImageResizer.exe";
+    private const string _OTHER_EXECUTABLE = @"D:\elsewhere\ImageResizer.exe";
+
+    private string _scratchPath;
+    private RegistryKey _classes;
+
+    [SetUp]
+    public void SetUp() {
+      this._scratchPath = @"Software\ImageResizer.Tests\" + Guid.NewGuid().ToString("N");
+      this._classes = Registry.CurrentUser.CreateSubKey(this._scratchPath);
+    }
+
+    [TearDown]
+    public void TearDown() {
+      this._classes?.Dispose();
+      try {
+        Registry.CurrentUser.DeleteSubKeyTree(this._scratchPath, false);
+      } catch (Exception) {
+        // a leftover scratch key must not fail the run
+      }
+    }
+
+    #region registering
+
+    [Test]
+    public void RegisteringMakesTheExtensionResolveToTheExecutable() {
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+
+      Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE), Is.True);
+    }
+
+    [Test]
+    public void RegisteringPointsTheExtensionAtTheProgramIdentifier() {
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+
+      using (var extension = this._classes.OpenSubKey(ScriptSerializer.DEFAULT_FILE_EXTENSION))
+        Assert.That(extension.GetValue(null), Is.EqualTo(ScriptFileAssociation.PROGRAM_IDENTIFIER));
+    }
+
+    [Test]
+    public void RegisteringWritesTheOpenCommandWithAQuotedPlaceholder() {
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+
+      using (var command = this._classes.OpenSubKey(ScriptFileAssociation.PROGRAM_IDENTIFIER + @"\shell\open\command"))
+        Assert.That(command.GetValue(null), Is.EqualTo("\"" + _EXECUTABLE + "\" \"%1\""));
+    }
+
+    [Test]
+    public void TheCommandQuotesTheFile_SoAPathWithSpacesSurvives()
+      => Assert.That(ScriptFileAssociation.BuildCommand(_EXECUTABLE), Does.EndWith("\"%1\""))
+    ;
+
+    [Test]
+    public void RegisteringWritesADescriptionAndAnIcon() {
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+
+      using (var program = this._classes.OpenSubKey(ScriptFileAssociation.PROGRAM_IDENTIFIER))
+        Assert.That(program.GetValue(null), Is.EqualTo(ScriptFileAssociation.FILE_TYPE_DESCRIPTION));
+
+      using (var icon = this._classes.OpenSubKey(ScriptFileAssociation.PROGRAM_IDENTIFIER + @"\DefaultIcon"))
+        Assert.That(icon.GetValue(null), Is.EqualTo(_EXECUTABLE + ",0"));
+    }
+
+    [Test]
+    public void RegisteringTwiceIsHarmless() {
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+
+      Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE), Is.True);
+    }
+
+    [Test]
+    public void RegisteringAgainFromANewLocationRepointsTheAssociation() {
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+
+      ScriptFileAssociation.Register(this._classes, _OTHER_EXECUTABLE);
+
+      Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _OTHER_EXECUTABLE), Is.True);
+      Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE), Is.False);
+    }
+
+    #endregion
+
+    #region reporting state
+
+    [Test]
+    public void NothingIsRegisteredToBeginWith()
+      => Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE), Is.False)
+    ;
+
+    [Test]
+    public void AnAssociationToADifferentExecutable_IsNotOurs() {
+      ScriptFileAssociation.Register(this._classes, _OTHER_EXECUTABLE);
+
+      Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE), Is.False);
+    }
+
+    [Test]
+    public void AnExtensionOwnedBySomethingElse_IsNotOurs() {
+      using (var extension = this._classes.CreateSubKey(ScriptSerializer.DEFAULT_FILE_EXTENSION))
+        extension.SetValue(null, "SomeOtherEditor.Script");
+
+      Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE), Is.False);
+    }
+
+    [Test]
+    public void TheExecutableIsMatchedCaseInsensitively() {
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+
+      Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE.ToUpperInvariant()), Is.True);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void AnEmptyExecutable_IsNeverRegistered(string executable)
+      => Assert.That(ScriptFileAssociation.IsRegistered(this._classes, executable), Is.False)
+    ;
+
+    [Test]
+    public void AMissingRegistryRoot_IsNotRegistered()
+      => Assert.That(ScriptFileAssociation.IsRegistered(null, _EXECUTABLE), Is.False)
+    ;
+
+    #endregion
+
+    #region removing
+
+    [Test]
+    public void UnregisteringRemovesTheAssociation() {
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+
+      ScriptFileAssociation.Unregister(this._classes);
+
+      Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE), Is.False);
+      Assert.That(this._classes.OpenSubKey(ScriptFileAssociation.PROGRAM_IDENTIFIER), Is.Null);
+    }
+
+    [Test]
+    public void UnregisteringWhenNothingIsRegistered_IsHarmless()
+      => Assert.That(() => ScriptFileAssociation.Unregister(this._classes), Throws.Nothing)
+    ;
+
+    /// <summary>
+    /// Another program may have taken the extension over since. Stealing it back on the way out
+    /// would be worse than leaving it alone.
+    /// </summary>
+    [Test]
+    public void UnregisteringLeavesAnExtensionOwnedBySomethingElseAlone() {
+      ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+      using (var extension = this._classes.CreateSubKey(ScriptSerializer.DEFAULT_FILE_EXTENSION))
+        extension.SetValue(null, "SomeOtherEditor.Script");
+
+      ScriptFileAssociation.Unregister(this._classes);
+
+      using (var extension = this._classes.OpenSubKey(ScriptSerializer.DEFAULT_FILE_EXTENSION))
+        Assert.That(extension?.GetValue(null), Is.EqualTo("SomeOtherEditor.Script"));
+    }
+
+    [Test]
+    public void RegisteringAndRemovingRoundTrips() {
+      for (var i = 0; i < 3; ++i) {
+        ScriptFileAssociation.Register(this._classes, _EXECUTABLE);
+        Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE), Is.True);
+
+        ScriptFileAssociation.Unregister(this._classes);
+        Assert.That(ScriptFileAssociation.IsRegistered(this._classes, _EXECUTABLE), Is.False);
+      }
+    }
+
+    #endregion
+
+  }
+}


### PR DESCRIPTION
Closes #13. Stacked on the config persistence PR.

Running a script by double clicking it needs two halves: the executable has to *understand* a bare script file name, and the shell has to *send* it one. The first half landed with #12; this is the second.

A Tools menu entry toggles the association and shows a tick while scripts open with this build, so one place both makes and removes it.

## Where it writes

`HKEY_CURRENT_USER\Software\Classes` — no elevation, no effect on other users:

| Key | Value |
|---|---|
| `.irs` | `ImageResizer.Script` |
| `ImageResizer.Script` | `ImageResizer Script` |
| `ImageResizer.Script\DefaultIcon` | `<exe>,0` |
| `ImageResizer.Script\shell\open\command` | `"<exe>" "%1"` |

`SHChangeNotify` tells Explorer, so the icon and verb appear without a logoff. The `%1` is quoted, so a script in a path with spaces still opens.

Removing the association leaves the extension alone when something else has taken it over since — stealing it back on the way out would be worse than leaving it.

## Tests

The registry root is a parameter, so **20 new tests** run against a scratch key created per test and deleted afterwards. The user's real associations are never touched. They cover registering, re-pointing after the executable moves, case-insensitive matching, an extension owned by another program, removal, and repeated round trips.

**620 tests green.**