### PR TITLE
# transparent pixels lost the colour they were hiding

### DIFF
--- a/ImageResizer/Classes/BitmapLoader.cs
+++ b/ImageResizer/Classes/BitmapLoader.cs
@@ -1,0 +1,84 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+
+namespace Classes {
+  /// <summary>
+  /// Turns a freshly loaded image into the standalone 32bpp ARGB bitmap the pipeline works on.
+  /// </summary>
+  internal static class BitmapLoader {
+
+    /// <summary>
+    /// Copies an image into an independent bitmap without losing anything.
+    /// <para>
+    /// The copy is a pixel clone rather than a redraw. Drawing an image onto a fresh surface
+    /// composites it, and compositing a fully transparent pixel throws its colour away - the
+    /// magenta behind a sprite's transparent background came out as black, so the background
+    /// colour had to be restored by hand afterwards.
+    /// </para>
+    /// <para>
+    /// Cloning also sidesteps the DPI trap that the redraw needed an explicit pixel rectangle to
+    /// avoid: it works in pixels and never consults the resolution metadata.
+    /// </para>
+    /// </summary>
+    /// <para>
+    /// The pixels are copied out byte for byte rather than cloned: a clone can share the loader's
+    /// storage, which keeps the source file mapped and locked, and releasing the file is the
+    /// whole reason this copy exists.
+    /// </para>
+    /// <param name="image">The loaded image; the caller still owns and disposes it.</param>
+    /// <returns>An independent bitmap holding no reference to the loader or its stream.</returns>
+    public static Bitmap CopyPreservingTransparency(Image image) {
+      if (!(image is Bitmap bitmap)) {
+        // metafiles and the like have no pixels to copy; compositing is all there is
+        var drawn = new Bitmap(image.Width, image.Height, PixelFormat.Format32bppArgb);
+        using (var graphics = Graphics.FromImage(drawn))
+          graphics.DrawImage(image, 0, 0, image.Width, image.Height);
+
+        return drawn;
+      }
+
+      var bounds = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
+      var copy = new Bitmap(bounds.Width, bounds.Height, PixelFormat.Format32bppArgb);
+
+      // LockBits converts an indexed or lower-depth source on the way out, palette alpha included
+      var read = bitmap.LockBits(bounds, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+      try {
+        var write = copy.LockBits(bounds, ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
+        try {
+          var row = new byte[bounds.Width * 4];
+          for (var y = 0; y < bounds.Height; ++y) {
+            Marshal.Copy(read.Scan0 + y * read.Stride, row, 0, row.Length);
+            Marshal.Copy(row, 0, write.Scan0 + y * write.Stride, row.Length);
+          }
+        } finally {
+          copy.UnlockBits(write);
+        }
+      } finally {
+        bitmap.UnlockBits(read);
+      }
+
+      return copy;
+    }
+  }
+}

--- a/ImageResizer/Classes/BitmapMasterPool.cs
+++ b/ImageResizer/Classes/BitmapMasterPool.cs
@@ -1,4 +1,4 @@
-#region (c)2008-2026 Hawkynt
+﻿#region (c)2008-2026 Hawkynt
 /*
  *  Image filtering library
     Copyright (C) 2008-2026 Hawkynt
@@ -259,17 +259,8 @@ namespace Classes {
     /// the image is disposed, so we draw it into a fresh 32bpp ARGB bitmap and discard the loader.
     /// </summary>
     private static Bitmap _LoadFromDisk(string absolutePath) {
-      using (var loaded = Image.FromFile(absolutePath)) {
-        var copy = new Bitmap(loaded.Width, loaded.Height, PixelFormat.Format32bppArgb);
-        using (var g = Graphics.FromImage(copy))
-          // DrawImage with explicit pixel rect, NOT DrawImageUnscaled. The latter is DPI-aware:
-          // it paints the source at its physical (inches) size, so a 72-DPI image drawn onto a
-          // 96-DPI Graphics is scaled up by 96/72 ≈ 1.33×, gets clipped against the same-pixel-
-          // dimensioned destination, and you see only the upper-left 75% of the image. The
-          // explicit pixel-rect overload forces a 1:1 pixel copy regardless of DPI metadata.
-          g.DrawImage(loaded, 0, 0, loaded.Width, loaded.Height);
-        return copy;
-      }
+      using (var loaded = Image.FromFile(absolutePath))
+        return BitmapLoader.CopyPreservingTransparency(loaded);
     }
   }
 }

--- a/ImageResizer/Classes/ScriptActions/LoadFileCommand.cs
+++ b/ImageResizer/Classes/ScriptActions/LoadFileCommand.cs
@@ -1,4 +1,4 @@
-#region (c)2008-2026 Hawkynt
+﻿#region (c)2008-2026 Hawkynt
 /*
  *  Image filtering library
     Copyright (C) 2008-2026 Hawkynt
@@ -47,7 +47,7 @@ namespace Classes.ScriptActions {
       // Legacy engine-owned path: copy the loader output into a standalone Bitmap so the file
       // handle is released before we hand ownership to the engine.
       using (var image = Image.FromFile(this.FileName))
-        this.SourceImage = this.GdiSource = new Bitmap(image);
+        this.SourceImage = this.GdiSource = BitmapLoader.CopyPreservingTransparency(image);
 
       this.PoolSourceKey = null;
       return true;

--- a/ImageResizer/Classes/ScriptActions/LoadStdInCommand.cs
+++ b/ImageResizer/Classes/ScriptActions/LoadStdInCommand.cs
@@ -1,4 +1,4 @@
-#region (c)2008-2026 Hawkynt
+﻿#region (c)2008-2026 Hawkynt
 /*
  *  Image filtering library
     Copyright (C) 2008-2026 Hawkynt
@@ -31,7 +31,7 @@ namespace Classes.ScriptActions {
     public bool Execute() {
       using (var stream = Console.OpenStandardInput())
       using (var image = Image.FromStream(stream, false))
-        this.SourceImage = this.GdiSource = new Bitmap(image);
+        this.SourceImage = this.GdiSource = BitmapLoader.CopyPreservingTransparency(image);
       return true;
     }
 

--- a/Tests/ImageResizer.Tests/TransparencyPreservationTests.cs
+++ b/Tests/ImageResizer.Tests/TransparencyPreservationTests.cs
@@ -1,0 +1,236 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+using Classes;
+using Classes.ScriptActions;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// A transparent pixel still has a colour, and sprite workflows depend on it: the background
+  /// index of a paletted sprite has to survive a trip through the application or it has to be
+  /// restored by hand afterwards. These pin that it does.
+  /// </summary>
+  [TestFixture]
+  public class TransparencyPreservationTests {
+
+    /// <summary>The colour hiding behind full transparency.</summary>
+    private static readonly Color _BACKGROUND = Color.FromArgb(0, 255, 0, 255);
+
+    private TemporaryDirectory _directory;
+
+    [SetUp]
+    public void SetUp() => this._directory = new TemporaryDirectory();
+
+    [TearDown]
+    public void TearDown() => this._directory.Dispose();
+
+    #region helpers
+
+    /// <summary>A sprite with a transparent-but-coloured border and an opaque middle.</summary>
+    private static Bitmap _Sprite(int size = 16) {
+      var result = new Bitmap(size, size, PixelFormat.Format32bppArgb);
+      for (var y = 0; y < size; ++y)
+      for (var x = 0; x < size; ++x) {
+        var inside = x >= size / 4 && x < size * 3 / 4 && y >= size / 4 && y < size * 3 / 4;
+        result.SetPixel(x, y, inside ? Color.FromArgb(255, 0, 128, 0) : _BACKGROUND);
+      }
+
+      return result;
+    }
+
+    /// <summary>An 8 bit paletted sprite whose first palette entry is the transparent background.</summary>
+    private static Bitmap _PalettedSprite(int size = 16) {
+      var result = new Bitmap(size, size, PixelFormat.Format8bppIndexed);
+
+      var palette = result.Palette;
+      palette.Entries[0] = _BACKGROUND;
+      palette.Entries[1] = Color.FromArgb(255, 0, 128, 0);
+      result.Palette = palette;
+
+      var data = result.LockBits(new Rectangle(0, 0, size, size), ImageLockMode.WriteOnly, PixelFormat.Format8bppIndexed);
+      try {
+        var row = new byte[data.Stride];
+        for (var y = 0; y < size; ++y) {
+          for (var x = 0; x < size; ++x) {
+            var inside = x >= size / 4 && x < size * 3 / 4 && y >= size / 4 && y < size * 3 / 4;
+            row[x] = (byte)(inside ? 1 : 0);
+          }
+
+          Marshal.Copy(row, 0, data.Scan0 + y * data.Stride, data.Stride);
+        }
+      } finally {
+        result.UnlockBits(data);
+      }
+
+      return result;
+    }
+
+    private static Color _TopLeft(Bitmap bitmap) => bitmap.GetPixel(0, 0);
+
+    #endregion
+
+    #region the copy itself
+
+    [Test]
+    public void CopyingAnImage_KeepsTheColourUnderTransparency() {
+      using (var source = _Sprite())
+      using (var copy = BitmapLoader.CopyPreservingTransparency(source)) {
+        Assert.That(_TopLeft(copy).ToArgb(), Is.EqualTo(_BACKGROUND.ToArgb()));
+      }
+    }
+
+    [Test]
+    public void CopyingAnImage_KeepsTheOpaquePixels() {
+      using (var source = _Sprite())
+      using (var copy = BitmapLoader.CopyPreservingTransparency(source)) {
+        Assert.That(copy.GetPixel(8, 8).ToArgb(), Is.EqualTo(Color.FromArgb(255, 0, 128, 0).ToArgb()));
+      }
+    }
+
+    [Test]
+    public void CopyingAnImage_ProducesAThirtyTwoBitArgbBitmap() {
+      using (var source = _PalettedSprite())
+      using (var copy = BitmapLoader.CopyPreservingTransparency(source)) {
+        Assert.That(copy.PixelFormat, Is.EqualTo(PixelFormat.Format32bppArgb));
+      }
+    }
+
+    [Test]
+    public void CopyingAPalettedImage_KeepsItsTransparentPaletteEntry() {
+      using (var source = _PalettedSprite())
+      using (var copy = BitmapLoader.CopyPreservingTransparency(source)) {
+        Assert.That(_TopLeft(copy).A, Is.Zero);
+        Assert.That(_TopLeft(copy).ToArgb(), Is.EqualTo(_BACKGROUND.ToArgb()));
+      }
+    }
+
+    [Test]
+    public void CopyingKeepsTheDimensions() {
+      using (var source = _Sprite(23))
+      using (var copy = BitmapLoader.CopyPreservingTransparency(source)) {
+        Assert.That(copy.Size, Is.EqualTo(new Size(23, 23)));
+      }
+    }
+
+    #endregion
+
+    #region through the loader
+
+    [Test]
+    public void LoadingASprite_KeepsTheColourUnderTransparency() {
+      var file = this._directory.File("sprite.png");
+      using (var sprite = _Sprite())
+        sprite.Save(file, ImageFormat.Png);
+
+      var command = new LoadFileCommand(file);
+      command.Execute();
+
+      Assert.That(_TopLeft(command.SourceImage).ToArgb(), Is.EqualTo(_BACKGROUND.ToArgb()));
+    }
+
+    [Test]
+    public void LoadingAPalettedSprite_KeepsTheColourUnderTransparency() {
+      var file = this._directory.File("paletted.png");
+      using (var sprite = _PalettedSprite())
+        sprite.Save(file, ImageFormat.Png);
+
+      var command = new LoadFileCommand(file);
+      command.Execute();
+
+      Assert.That(_TopLeft(command.SourceImage).A, Is.Zero);
+      Assert.That(_TopLeft(command.SourceImage).ToArgb(), Is.EqualTo(_BACKGROUND.ToArgb()));
+    }
+
+    [Test]
+    public void LoadingStillReleasesTheFile() {
+      var file = this._directory.File("sprite.png");
+      using (var sprite = _Sprite())
+        sprite.Save(file, ImageFormat.Png);
+
+      new LoadFileCommand(file).Execute();
+
+      Assert.That(() => System.IO.File.Delete(file), Throws.Nothing, "cloning must not keep the loader's handle open");
+    }
+
+    #endregion
+
+    #region through a whole run
+
+    /// <summary>
+    /// Issue #32: the background colour of a paletted sprite has to come out the other side of a
+    /// scale unchanged, or it has to be put back by hand before the sprite is usable again.
+    /// </summary>
+    [TestCase("Upscaler: XBR NoBlend 4x")]
+    [TestCase("Upscaler: HQ 2x")]
+    [TestCase("Upscaler: Scale 2x")]
+    public void ScalingASprite_KeepsItsTransparentBackgroundColour(string filter) {
+      var input = this._directory.File("sprite.png");
+      var output = this._directory.File("out.png");
+      using (var sprite = _Sprite())
+        sprite.Save(input, ImageFormat.Png);
+
+      var engine = new ScriptEngine();
+      ScriptSerializer.LoadFromString(engine, $@"""/load"" ""{input}"" ""/resize"" ""auto"" ""{filter}"" ""/save"" ""{output}""");
+      engine.RepeatActions();
+
+      using (var stream = new System.IO.FileStream(output, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read))
+      using (var result = new Bitmap(stream)) {
+        Assert.That(_TopLeft(result).A, Is.Zero, "the background must stay transparent");
+        Assert.That(_TopLeft(result).ToArgb(), Is.EqualTo(_BACKGROUND.ToArgb()), "and must keep the colour it had");
+      }
+    }
+
+    [Test]
+    public void ScalingASprite_LeavesExactlyOneColourUnderTheTransparency() {
+      var input = this._directory.File("sprite.png");
+      var output = this._directory.File("out.png");
+      using (var sprite = _Sprite())
+        sprite.Save(input, ImageFormat.Png);
+
+      var engine = new ScriptEngine();
+      ScriptSerializer.LoadFromString(engine, $@"""/load"" ""{input}"" ""/resize"" ""auto"" ""Upscaler: XBR NoBlend 4x"" ""/save"" ""{output}""");
+      engine.RepeatActions();
+
+      using (var stream = new System.IO.FileStream(output, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read))
+      using (var result = new Bitmap(stream)) {
+        var transparent = Enumerable
+          .Range(0, result.Height)
+          .SelectMany(y => Enumerable.Range(0, result.Width).Select(x => result.GetPixel(x, y)))
+          .Where(colour => colour.A == 0)
+          .Select(colour => Color.FromArgb(255, colour).ToArgb())
+          .Distinct()
+          .ToArray()
+          ;
+
+        Assert.That(transparent, Is.EqualTo(new[] { Color.FromArgb(255, _BACKGROUND).ToArgb() }));
+      }
+    }
+
+    #endregion
+
+  }
+}


### PR DESCRIPTION
Closes #32.

## Cause

A transparent pixel still has a colour, and sprite workflows depend on it. Loading drew the image onto a fresh surface, and compositing a fully transparent pixel throws its colour away.

Traced through GDI+ directly:

```
Image.FromFile(sprite.png)  -> Color [A=0, R=255, G=0, B=255]   correct
new Bitmap(image)           -> Color [A=0, R=0,   G=0, B=0]     colour gone
```

So a sprite with a magenta transparent background came out with a black one, and the background had to be picked back out by hand before the sprite was usable — which is what the report describes.

Three places copied a loaded image this way: `LoadFileCommand`, `LoadStdInCommand` and `BitmapMasterPool`.

## Change

The pixels are copied out byte for byte through `LockBits` into a fresh 32bpp ARGB bitmap.

Deliberately **not** a `Clone` — I tried that first and it broke the existing handle-release test. `Bitmap.Clone` can share the loader's storage, which keeps the source file mapped and locked, and releasing the file is the whole reason this copy exists. That test caught it, which is the point of having it.

The copy also sidesteps a hazard the old code carried a comment about: `DrawImage` needed an explicit pixel rectangle to avoid being scaled by the source's DPI metadata. Copying pixels never consults it.

## Verification

Round trip of a paletted sprite (index 0 = magenta, marked transparent via `tRNS`) through `XBR NoBlend 4x`:

```
before: background pixel = (0, 0, 0, 0)
after:  background pixel = (255, 0, 255, 0)
```

Alpha stays 0 and the colour survives, both for a plain load/save and through a scale.

## Tests

**14 new tests**: the copy itself for 32bpp and 8bpp indexed sources, that it still releases the file, loading through `LoadFileCommand`, and a whole-run check across three upscalers asserting the background keeps both its transparency and its colour — plus one that the scaled output has exactly one colour under its transparency.

**542 tests green.**

## Not in scope

The output is written as RGBA rather than as a paletted PNG. The transparency and its colour both survive, so the sprite is usable as-is, but a source that was 8-bit paletted does not come back 8-bit paletted. Re-quantising the output back into a palette is a separate piece of work — the Reduce Colours tool already does quantisation and would be the place for it.