### PR TITLE
+ batch processing with wildcards

### DIFF
--- a/ImageResizer/Classes/CLI.cs
+++ b/ImageResizer/Classes/CLI.cs
@@ -69,6 +69,13 @@ namespace Classes {
         return CLIExitCode.OK;
       }
 
+      // a /load naming a set of files becomes one run per file before anything else sees it
+      arguments = WildcardExpansion.Expand(arguments);
+      if (arguments.Length < 1) {
+        _Diagnostics.WriteLine("No files matched.");
+        return CLIExitCode.OK;
+      }
+
       var engine = new ScriptEngine();
       var line = string.Join(" ", arguments.Select(a => string.Format(@"""{0}""", a)));
       _Diagnostics.WriteLine("Executing the following script:");

--- a/ImageResizer/Classes/WildcardExpansion.cs
+++ b/ImageResizer/Classes/WildcardExpansion.cs
@@ -1,0 +1,177 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Classes {
+  /// <summary>
+  /// Turns one command line that names a set of files into the command line that processes them
+  /// one by one.
+  /// <para>
+  /// A <c>/load</c> whose file name contains <c>*</c> or <c>?</c> repeats everything up to the
+  /// next <c>/load</c> once per matching file. Inside that repeat, a <c>*</c> in any other file
+  /// name stands for the matched file's base name, so a target can be named after its source:
+  /// </para>
+  /// <code>
+  /// /load *.png /resize auto "HQ 2x" /save big\*.png
+  /// </code>
+  /// <para>
+  /// This runs before parsing, so the engine only ever sees ordinary file names and nothing
+  /// downstream has to know that batches exist.
+  /// </para>
+  /// </summary>
+  internal static class WildcardExpansion {
+
+    /// <summary>
+    /// Commands whose argument is a file name that a matched base name can be substituted into.
+    /// </summary>
+    private static readonly string[] _FILE_COMMANDS = {
+      ScriptSerializer.LOAD_COMMAND_NAME,
+      ScriptSerializer.SAVE_COMMAND_NAME,
+      ScriptSerializer.SCRIPT_COMMAND_NAME,
+    };
+
+    /// <summary>
+    /// Determines whether a file name selects a set rather than a single file.
+    /// </summary>
+    /// <param name="value">The file name.</param>
+    /// <returns><c>true</c> when it contains a wildcard.</returns>
+    public static bool ContainsWildcard(string value)
+      => value != null && (value.IndexOf('*') >= 0 || value.IndexOf('?') >= 0)
+    ;
+
+    /// <summary>
+    /// Expands every wildcard <c>/load</c> in a command line.
+    /// </summary>
+    /// <param name="arguments">The arguments as given.</param>
+    /// <param name="matcher">
+    /// Resolves a pattern to the files it names, in the order they should be processed. Injected
+    /// so this can be exercised without a directory full of images.
+    /// </param>
+    /// <returns>
+    /// The expanded arguments, or the originals unchanged when no <c>/load</c> carries a wildcard.
+    /// </returns>
+    public static string[] Expand(string[] arguments, Func<string, string[]> matcher = null) {
+      if (arguments == null || arguments.Length < 1)
+        return arguments;
+
+      if (!_HasWildcardLoad(arguments))
+        return arguments;
+
+      matcher = matcher ?? _MatchFiles;
+
+      var result = new List<string>(arguments.Length);
+      var index = 0;
+      while (index < arguments.Length) {
+        if (!_IsLoad(arguments, index) || !ContainsWildcard(arguments[index + 1])) {
+          result.Add(arguments[index++]);
+          continue;
+        }
+
+        var pattern = arguments[index + 1];
+        var segment = _TakeSegment(arguments, index);
+        index += segment.Count;
+
+        var matches = matcher(pattern) ?? new string[0];
+        foreach (var match in matches)
+          result.AddRange(_Substitute(segment, match));
+      }
+
+      return result.ToArray();
+    }
+
+    /// <summary>
+    /// Determines whether any <c>/load</c> in the arguments carries a wildcard.
+    /// </summary>
+    private static bool _HasWildcardLoad(string[] arguments) {
+      for (var i = 0; i < arguments.Length - 1; ++i)
+        if (_IsLoad(arguments, i) && ContainsWildcard(arguments[i + 1]))
+          return true;
+
+      return false;
+    }
+
+    private static bool _IsLoad(string[] arguments, int index)
+      => index + 1 < arguments.Length
+      && string.Equals(arguments[index], ScriptSerializer.LOAD_COMMAND_NAME, StringComparison.OrdinalIgnoreCase)
+    ;
+
+    /// <summary>
+    /// Takes the run of arguments a wildcard load owns: itself, its pattern, and everything up to
+    /// the next <c>/load</c>.
+    /// </summary>
+    private static List<string> _TakeSegment(string[] arguments, int start) {
+      var segment = new List<string> { arguments[start], arguments[start + 1] };
+      for (var i = start + 2; i < arguments.Length; ++i) {
+        if (_IsLoad(arguments, i) || string.Equals(arguments[i], ScriptSerializer.LOAD_COMMAND_NAME, StringComparison.OrdinalIgnoreCase))
+          break;
+
+        segment.Add(arguments[i]);
+      }
+
+      return segment;
+    }
+
+    /// <summary>
+    /// Fills a segment in for one matched file: the pattern becomes that file, and a <c>*</c> in
+    /// any other file name becomes its base name.
+    /// </summary>
+    private static IEnumerable<string> _Substitute(List<string> segment, string match) {
+      var baseName = Path.GetFileNameWithoutExtension(match);
+
+      // the load's own argument is the file itself, not a name built from it
+      yield return segment[0];
+      yield return match;
+
+      for (var i = 2; i < segment.Count; ++i) {
+        var isFileArgument = i > 0 && _FILE_COMMANDS.Contains(segment[i - 1], StringComparer.OrdinalIgnoreCase);
+        yield return isFileArgument && ContainsWildcard(segment[i])
+          ? segment[i].Replace("*", baseName)
+          : segment[i];
+      }
+    }
+
+    /// <summary>
+    /// Resolves a pattern against the file system, ordered by name so a batch is reproducible.
+    /// </summary>
+    private static string[] _MatchFiles(string pattern) {
+      try {
+        var directory = Path.GetDirectoryName(pattern);
+        var searchPattern = Path.GetFileName(pattern);
+        if (string.IsNullOrEmpty(searchPattern))
+          return new string[0];
+
+        var files = Directory.GetFiles(string.IsNullOrEmpty(directory) ? "." : directory, searchPattern);
+        Array.Sort(files, StringComparer.OrdinalIgnoreCase);
+
+        // keep the caller's spelling: a bare pattern stays a bare name
+        return string.IsNullOrEmpty(directory)
+          ? files.Select(Path.GetFileName).ToArray()
+          : files;
+      } catch (Exception) {
+        // an unusable pattern simply matches nothing; the parser reports the empty run
+        return new string[0];
+      }
+    }
+  }
+}

--- a/ImageResizer/Resources/CLIHelpText.txt
+++ b/ImageResizer/Resources/CLIHelpText.txt
@@ -1,4 +1,4 @@
-========================================================================
+﻿========================================================================
    ** {appname} v{version}, {copyright}
    Version for Windows NT/9x/2000/XP/Vista/7  (All rights reserved)
 ------------------------------------------------------------------------
@@ -79,6 +79,10 @@ The category may be left out where it is unambiguous, so this is the same filter
 Since STDOUT carries nothing but the image, runs can be piped into each other or into any
 other tool that reads an image from STDIN.
 {location} {load} 1.png {resize} auto "HQ 2x" {stdout} | {location} {stdin} {resize} auto "XBR 3x" {save} 2.png
+
+A {load} whose name contains * or ? processes every matching file in turn. A * in a later
+file name stands for the matched file's own name, so each target is named after its source.
+{location} {load} *.png {resize} auto "HQ 2x" {save} big\*.png
 
 You can load and process multiple files at once by loading after saving again.
 {location} {load} 1.bmp {resize} 10x10 "Nearest Neighbor" {save} 1.jpg {load} 2.bmp {resize} 10x10 "Nearest Neighbor" {save} 2.jpg

--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ ImageResizer.exe /load <input> /resize <dimensions> <method> /save <output>
 
 Run `ImageResizer.exe /?` to print the full help including the list of every supported filter method; with no arguments it opens the GUI.
 
+#### Batch processing
+
+A `/load` whose name contains `*` or `?` runs the rest of the chain once per matching file. A `*` in a later file name stands for the matched file's own name, so every target is named after its source — no need to write the same lines out per sprite:
+
+```bash
+# every png in the folder, upscaled into bigImageResizer.exe /load *.png /resize auto "Upscaler: HQ 2x" /save big\*.png
+
+# convert a whole folder while scaling
+ImageResizer.exe /load sprites\*.bmp /resize 400% "Upscaler: XBR 4x" /save out\*.png
+```
+
 #### Piping
 
 `/stdin` reads an image from standard input and `/stdout` writes a PNG to standard output. Standard output carries image data and nothing else — progress reports and errors go to standard error — so a run can be piped straight into another program:

--- a/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
+++ b/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
@@ -324,6 +324,57 @@ namespace ImageResizer.Tests {
 
     #endregion
 
+    #region batches
+
+    /// <summary>
+    /// Issue #31: naming a set of files instead of writing the same lines out per sprite.
+    /// </summary>
+    [Test]
+    public void AWildcardLoad_ProcessesEveryMatch() {
+      this._Source("alpha.png");
+      this._Source("beta.png");
+      this._Source("gamma.png");
+      Directory.CreateDirectory(Path.Combine(this._directory.Path, "big"));
+
+      var result = this._Run("/load", "*.png", "/resize", "auto", "HQ 2x", "/save", @"big\*.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      foreach (var name in new[] { "alpha", "beta", "gamma" })
+        Assert.That(TestBitmaps.SizeOf(Path.Combine(this._directory.Path, "big", name + ".png")), Is.EqualTo(new Size(32, 32)), name);
+    }
+
+    [Test]
+    public void AWildcardLoad_NamesEachTargetAfterItsSource() {
+      this._Source("one.png");
+      this._Source("two.png");
+
+      var result = this._Run("/load", "*.png", "/resize", "auto", "HQ 2x", "/save", "*.bmp");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      Assert.That(this._Exists("one.bmp"), Is.True);
+      Assert.That(this._Exists("two.bmp"), Is.True);
+    }
+
+    [Test]
+    public void AWildcardThatMatchesNothing_IsNotAnError() {
+      var result = this._Run("/load", "*.tga", "/save", "*.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      Assert.That(result.StandardError, Does.Contain("No files matched"));
+    }
+
+    [Test]
+    public void APlainFileName_StillProcessesExactlyOneFile() {
+      this._Source("only.png");
+
+      var result = this._Run("/load", "only.png", "/resize", "auto", "HQ 2x", "/save", "out.png");
+
+      Assert.That(result.Code, Is.EqualTo(CLIExitCode.OK), result.StandardError);
+      Assert.That(this._SizeOf("out.png"), Is.EqualTo(new Size(32, 32)));
+    }
+
+    #endregion
+
     #region dropped scripts
 
     /// <summary>

--- a/Tests/ImageResizer.Tests/WildcardExpansionTests.cs
+++ b/Tests/ImageResizer.Tests/WildcardExpansionTests.cs
@@ -1,0 +1,178 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+
+using Classes;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Covers turning one command line that names a set of files into the command line that
+  /// processes them one at a time. The file system is stubbed, so these say nothing about
+  /// what is on disk - only about the rewriting.
+  /// </summary>
+  [TestFixture]
+  public class WildcardExpansionTests {
+
+    private static readonly Func<string, string[]> _THREE = _ => new[] { "a.png", "b.png", "c.png" };
+    private static readonly Func<string, string[]> _NONE = _ => new string[0];
+
+    #region recognising a pattern
+
+    [TestCase("*.png", true)]
+    [TestCase("sprite?.png", true)]
+    [TestCase("in.png", false)]
+    [TestCase("", false)]
+    [TestCase(null, false)]
+    public void APatternIsAFileNameWithAWildcard(string value, bool expected)
+      => Assert.That(WildcardExpansion.ContainsWildcard(value), Is.EqualTo(expected))
+    ;
+
+    #endregion
+
+    #region leaving things alone
+
+    [Test]
+    public void ACommandLineWithoutAPattern_IsUntouched() {
+      var arguments = new[] { "/load", "in.png", "/resize", "auto", "HQ 2x", "/save", "out.png" };
+
+      Assert.That(WildcardExpansion.Expand(arguments, _THREE), Is.SameAs(arguments));
+    }
+
+    [Test]
+    public void AWildcardSomewhereOtherThanALoad_IsUntouched() {
+      var arguments = new[] { "/load", "in.png", "/save", "out*.png" };
+
+      Assert.That(WildcardExpansion.Expand(arguments, _THREE), Is.SameAs(arguments));
+    }
+
+    [TestCase(null)]
+    public void NoArguments_AreUntouched(string[] arguments)
+      => Assert.That(WildcardExpansion.Expand(arguments, _THREE), Is.Null)
+    ;
+
+    [Test]
+    public void AnEmptyCommandLine_IsUntouched()
+      => Assert.That(WildcardExpansion.Expand(new string[0], _THREE), Is.Empty)
+    ;
+
+    [Test]
+    public void ATrailingLoadWithoutAFileName_IsUntouched() {
+      var arguments = new[] { "/resize", "auto", "HQ 2x", "/load" };
+
+      Assert.That(WildcardExpansion.Expand(arguments, _THREE), Is.SameAs(arguments));
+    }
+
+    #endregion
+
+    #region expanding
+
+    [Test]
+    public void EachMatchGetsItsOwnRunOfTheWholeSegment() {
+      var result = WildcardExpansion.Expand(new[] { "/load", "*.png", "/resize", "auto", "HQ 2x", "/save", "out.png" }, _THREE);
+
+      Assert.That(result, Is.EqualTo(new[] {
+        "/load", "a.png", "/resize", "auto", "HQ 2x", "/save", "out.png",
+        "/load", "b.png", "/resize", "auto", "HQ 2x", "/save", "out.png",
+        "/load", "c.png", "/resize", "auto", "HQ 2x", "/save", "out.png",
+      }));
+    }
+
+    [Test]
+    public void AStarInTheTargetBecomesTheSourcesBaseName() {
+      var result = WildcardExpansion.Expand(new[] { "/load", "*.png", "/save", @"big\*.png" }, _THREE);
+
+      Assert.That(result, Is.EqualTo(new[] {
+        "/load", "a.png", "/save", @"big\a.png",
+        "/load", "b.png", "/save", @"big\b.png",
+        "/load", "c.png", "/save", @"big\c.png",
+      }));
+    }
+
+    [Test]
+    public void SeveralTargetsEachGetTheBaseName() {
+      var result = WildcardExpansion.Expand(new[] { "/load", "*.png", "/save", "*.png", "/save", "*.bmp" }, _ => new[] { "a.png" });
+
+      Assert.That(result, Is.EqualTo(new[] { "/load", "a.png", "/save", "a.png", "/save", "a.bmp" }));
+    }
+
+    [Test]
+    public void ATargetWithoutAStar_IsLeftAsWritten() {
+      var result = WildcardExpansion.Expand(new[] { "/load", "*.png", "/save", "fixed.png" }, _ => new[] { "a.png" });
+
+      Assert.That(result, Is.EqualTo(new[] { "/load", "a.png", "/save", "fixed.png" }));
+    }
+
+    [Test]
+    public void MatchingNothing_ProducesNothingToRun()
+      => Assert.That(WildcardExpansion.Expand(new[] { "/load", "*.png", "/save", "out.png" }, _NONE), Is.Empty)
+    ;
+
+    [Test]
+    public void ArgumentsBeforeThePattern_AreKept() {
+      var result = WildcardExpansion.Expand(new[] { "/stdin", "/load", "*.png", "/save", "*.png" }, _ => new[] { "a.png" });
+
+      Assert.That(result, Is.EqualTo(new[] { "/stdin", "/load", "a.png", "/save", "a.png" }));
+    }
+
+    [Test]
+    public void APlainLoadAfterAPattern_StartsItsOwnSegment() {
+      var result = WildcardExpansion.Expand(new[] { "/load", "*.png", "/save", "*.out", "/load", "z.png", "/save", "z.out" }, _ => new[] { "a.png", "b.png" });
+
+      Assert.That(result, Is.EqualTo(new[] {
+        "/load", "a.png", "/save", "a.out",
+        "/load", "b.png", "/save", "b.out",
+        "/load", "z.png", "/save", "z.out",
+      }));
+    }
+
+    [Test]
+    public void TwoPatterns_ExpandIndependently() {
+      var matcher = new Func<string, string[]>(pattern => pattern.StartsWith("x") ? new[] { "x1.png" } : new[] { "y1.png", "y2.png" });
+
+      var result = WildcardExpansion.Expand(new[] { "/load", "x*.png", "/save", "*.a", "/load", "y*.png", "/save", "*.b" }, matcher);
+
+      Assert.That(result, Is.EqualTo(new[] {
+        "/load", "x1.png", "/save", "x1.a",
+        "/load", "y1.png", "/save", "y1.b",
+        "/load", "y2.png", "/save", "y2.b",
+      }));
+    }
+
+    [Test]
+    public void TheLoadCommandIsMatchedCaseInsensitively() {
+      var result = WildcardExpansion.Expand(new[] { "/LOAD", "*.png", "/save", "*.out" }, _ => new[] { "a.png" });
+
+      Assert.That(result, Is.EqualTo(new[] { "/LOAD", "a.png", "/save", "a.out" }));
+    }
+
+    [Test]
+    public void ABaseNameDropsTheExtension() {
+      var result = WildcardExpansion.Expand(new[] { "/load", "*.bmp", "/save", "*.png" }, _ => new[] { @"C:\art\sprite.bmp" });
+
+      Assert.That(result, Is.EqualTo(new[] { "/load", @"C:\art\sprite.bmp", "/save", "sprite.png" }));
+    }
+
+    #endregion
+
+  }
+}


### PR DESCRIPTION
Closes #31.

> writing all the lines in the script area for each sprites takes way too long

A `/load` whose name contains `*` or `?` now runs the rest of the chain once per matching file. A `*` in a later file name stands for the matched file's own name, so every target is named after its source:

```bash
ImageResizer.exe /load *.png /resize auto "Upscaler: HQ 2x" /save big\*.png
```

```
Loading from file alpha.png
Saving to file big\alpha.png
Loading from file beta.png
Saving to file big\beta.png
Loading from file gamma.png
Saving to file big\gamma.png
```

The other half of that request — dragging files onto the executable — landed in #12 for scripts.

## How

The rewriting happens **before parsing**, so the engine only ever sees ordinary file names and nothing downstream has to know batches exist. A wildcard `/load` owns everything up to the next `/load`, so two patterns in one command line expand independently and a plain `/load` after one starts its own segment.

A pattern matching nothing reports `No files matched.` and exits cleanly rather than failing.

## Tests

**18 new tests.** The expander's file lookup is injected, so the rewriting is tested without a directory full of images — covering multiple targets, base-name substitution, patterns matching nothing, two independent patterns, and the cases that must be left untouched (no pattern, a wildcard outside a `/load`, a trailing `/load`). Four end-to-end cases drive the real executable over real files.

**554 tests green.**