### PR TITLE
+ percentage control, and a percentage that rounded to nothing no longer kills the run

### DIFF
--- a/ImageResizer/Classes/ScriptActions/ResizeCommand.cs
+++ b/ImageResizer/Classes/ScriptActions/ResizeCommand.cs
@@ -43,8 +43,9 @@ namespace Classes.ScriptActions {
       // overwrite dimensions from percentage if needed
       var percentage = this.Percentage;
       if (percentage > 0) {
-        width = (word)Math.Round(source.Width * percentage / 100d);
-        height = (word)Math.Round(source.Height * percentage / 100d);
+        TargetDimensions.FromPercentage(source.Width, source.Height, percentage, out var scaledWidth, out var scaledHeight);
+        width = (word)scaledWidth;
+        height = (word)scaledHeight;
       }
 
       // correct aspect ratio if needed

--- a/ImageResizer/Classes/TargetDimensions.cs
+++ b/ImageResizer/Classes/TargetDimensions.cs
@@ -1,0 +1,81 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+
+namespace Classes {
+  /// <summary>
+  /// Works out target dimensions from a relative size. Shared by the command line's
+  /// <c>/resize &lt;p&gt;%</c> and the window's percentage and scale-factor controls so the two
+  /// cannot drift apart.
+  /// </summary>
+  internal static class TargetDimensions {
+
+    /// <summary>
+    /// The smallest image that still exists. Rounding a small source down by a large factor
+    /// otherwise lands on zero, and a zero-sized bitmap cannot be allocated - which used to end
+    /// the run with a runtime error rather than a very small image.
+    /// </summary>
+    public const int MINIMUM = 1;
+
+    /// <summary>
+    /// Scales one dimension.
+    /// </summary>
+    /// <param name="source">The source length in pixels.</param>
+    /// <param name="factor">The factor to apply; 1.0 keeps the length.</param>
+    /// <param name="maximum">The largest length the caller can represent.</param>
+    /// <returns>The scaled length, at least <see cref="MINIMUM"/> and at most <paramref name="maximum"/>.</returns>
+    public static int Scale(int source, double factor, int maximum = ushort.MaxValue) {
+      if (source <= 0 || factor <= 0)
+        return MINIMUM;
+
+      var scaled = Math.Round(source * factor, MidpointRounding.ToEven);
+      if (scaled < MINIMUM)
+        return MINIMUM;
+
+      return scaled > maximum ? maximum : (int)scaled;
+    }
+
+    /// <summary>
+    /// Scales both dimensions by a percentage.
+    /// </summary>
+    /// <param name="sourceWidth">The source width.</param>
+    /// <param name="sourceHeight">The source height.</param>
+    /// <param name="percentage">The percentage; 100 keeps the size.</param>
+    /// <param name="width">Receives the target width.</param>
+    /// <param name="height">Receives the target height.</param>
+    /// <param name="maximum">The largest length the caller can represent.</param>
+    public static void FromPercentage(int sourceWidth, int sourceHeight, double percentage, out int width, out int height, int maximum = ushort.MaxValue) {
+      width = Scale(sourceWidth, percentage / 100d, maximum);
+      height = Scale(sourceHeight, percentage / 100d, maximum);
+    }
+
+    /// <summary>
+    /// Expresses a target size as a percentage of a source size, so the percentage control can
+    /// follow along when width or height is edited directly.
+    /// </summary>
+    /// <param name="source">The source length.</param>
+    /// <param name="target">The target length.</param>
+    /// <returns>The percentage, or <c>100</c> when the source has no size.</returns>
+    public static double ToPercentage(int source, int target)
+      => source <= 0 ? 100d : target * 100d / source
+    ;
+  }
+}

--- a/ImageResizer/MainForm.EventHandlers.cs
+++ b/ImageResizer/MainForm.EventHandlers.cs
@@ -271,6 +271,7 @@ namespace ImageResizer {
 
     private void nudWidth_ValueChanged(object sender, EventArgs e) {
       this._CorrectAspectRatioIfNeeded(false);
+      this._SyncPercentageFromWidth();
       this._SchedulePreview();
     }
 
@@ -290,10 +291,9 @@ namespace ImageResizer {
       var source = this._scriptEngine.SourceImage;
       if (source == null) return;
 
-      var targetW = (long)source.Width * factor;
-      var targetH = (long)source.Height * factor;
-      this.nudWidth.Value = (decimal)Math.Min(targetW, (long)this.nudWidth.Maximum);
-      this.nudHeight.Value = (decimal)Math.Min(targetH, (long)this.nudHeight.Maximum);
+      var maximum = (int)this.nudWidth.Maximum;
+      this.nudWidth.Value = TargetDimensions.Scale(source.Width, factor, maximum);
+      this.nudHeight.Value = TargetDimensions.Scale(source.Height, factor, maximum);
     }
 
     private void showToolStripMenuItem_Click(object sender, EventArgs e) {

--- a/ImageResizer/MainForm.cs
+++ b/ImageResizer/MainForm.cs
@@ -78,6 +78,18 @@ namespace ImageResizer {
     /// <see cref="_CreateCategoryFilter"/>.
     /// </summary>
     private ComboBox _cmbCategory;
+
+    /// <summary>
+    /// Sets the target size as a percentage of the source. Created in code by
+    /// <see cref="_CreatePercentageControl"/>.
+    /// </summary>
+    private NumericUpDown _nudPercentage;
+
+    /// <summary>
+    /// Guards the percentage control and the width/height boxes against driving each other in a
+    /// loop while one is being updated from the other.
+    /// </summary>
+    private bool _isApplyingPercentage;
     private CancellationTokenSource _previewCts;
 
     // The preview-owned bitmap currently shown in iwhTargetImage, if any. We OWN it and must
@@ -208,6 +220,7 @@ namespace ImageResizer {
       this.cmbResizeMethod.SelectedIndex = 0;
 
       this._CreateCategoryFilter();
+      this._CreatePercentageControl();
 
       this.cmbHorizontalBPH.DataSource = Enum.GetValues(typeof(OutOfBoundsMode));
       this.cmbVerticalBPH.DataSource = Enum.GetValues(typeof(OutOfBoundsMode));
@@ -321,6 +334,112 @@ namespace ImageResizer {
 
       var index = ManipulatorCategories.IndexOf(methods, previous);
       this.cmbResizeMethod.SelectedIndex = index < 0 ? 0 : index;
+    }
+
+    /// <summary>
+    /// Adds the percentage control to the target resolution group.
+    /// <para>
+    /// The fixed 2x..10x buttons only cover whole factors; a percentage covers everything between
+    /// and is what the command line has always accepted as <c>/resize &lt;p&gt;%</c>.
+    /// </para>
+    /// </summary>
+    private void _CreatePercentageControl() {
+      var group = this.nudWidth.Parent;
+      if (group == null)
+        return;
+
+      // The height row is the template for the new one. Its label sits a few pixels lower than
+      // its box, so both offsets are copied rather than guessed.
+      var heightLabel = group.Controls.OfType<Label>().FirstOrDefault(l => l.Text.StartsWith("Height", StringComparison.OrdinalIgnoreCase));
+      var rowHeight = this.nudHeight.Height + 6;
+      var newRowTop = this.nudHeight.Top + rowHeight;
+
+      this._nudPercentage = new NumericUpDown {
+        Name = "nudPercentage",
+        Location = new Point(this.nudHeight.Left, newRowTop),
+        Size = this.nudHeight.Size,
+        Anchor = this.nudHeight.Anchor,
+        Minimum = 1,
+        Maximum = 6400,
+        Value = 100,
+        Increment = 25,
+      };
+
+      // everything strictly below the height row moves down to make space - the height label
+      // itself sits below the box's top, so the boundary is the box's bottom edge
+      var heightRowBottom = this.nudHeight.Top + this.nudHeight.Height;
+      foreach (Control control in group.Controls)
+        if (control.Top >= heightRowBottom)
+          control.Top += rowHeight;
+
+      group.Height += rowHeight;
+      group.Controls.Add(this._nudPercentage);
+
+      if (heightLabel != null)
+        group.Controls.Add(new Label {
+          Name = "lblPercentage",
+          Text = "Percent",
+          Location = new Point(heightLabel.Left, heightLabel.Top + rowHeight),
+          Anchor = heightLabel.Anchor,
+          TextAlign = heightLabel.TextAlign,
+          // "Percent" is wider than the label this row was copied from
+          AutoSize = true,
+        });
+
+      this._nudPercentage.ValueChanged += this._OnPercentageChanged;
+    }
+
+    /// <summary>
+    /// Applies the percentage to the width and height boxes.
+    /// </summary>
+    private void _OnPercentageChanged(object sender, EventArgs e) {
+      if (this._isApplyingPercentage)
+        return;
+
+      var source = this._scriptEngine.SourceImage;
+      if (source == null)
+        return;
+
+      TargetDimensions.FromPercentage(
+        source.Width,
+        source.Height,
+        (double)this._nudPercentage.Value,
+        out var width,
+        out var height,
+        (int)this.nudWidth.Maximum
+      );
+
+      this._isApplyingPercentage = true;
+      try {
+        this.nudWidth.Value = width;
+        this.nudHeight.Value = height;
+      } finally {
+        this._isApplyingPercentage = false;
+      }
+    }
+
+    /// <summary>
+    /// Follows the width box with the percentage control, so the two never disagree about what
+    /// the target size is.
+    /// </summary>
+    private void _SyncPercentageFromWidth() {
+      if (this._isApplyingPercentage || this._nudPercentage == null)
+        return;
+
+      var source = this._scriptEngine.SourceImage;
+      if (source == null)
+        return;
+
+      var percentage = (decimal)TargetDimensions.ToPercentage(source.Width, (int)this.nudWidth.Value);
+      if (percentage < this._nudPercentage.Minimum || percentage > this._nudPercentage.Maximum)
+        return;
+
+      this._isApplyingPercentage = true;
+      try {
+        this._nudPercentage.Value = decimal.Round(percentage, 0);
+      } finally {
+        this._isApplyingPercentage = false;
+      }
     }
 
     /// <summary>

--- a/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
+++ b/Tests/ImageResizer.Tests/CommandLineEndToEndTests.cs
@@ -217,6 +217,9 @@ namespace ImageResizer.Tests {
     [TestCase("h48", 48, 48)]
     [TestCase("325%", 52, 52)]
     [TestCase("100%", 16, 16)]
+    // a percentage that rounds below a pixel used to end the run with a runtime error
+    [TestCase("1%", 1, 1)]
+    [TestCase("50%", 8, 8)]
     public void EveryDimensionForm_ReachesItsTarget(string dimensions, int expectedWidth, int expectedHeight) {
       var result = this._Run("/load", this._Source(), "/resize", dimensions, "Resampler: Bicubic", "/save", "out.png");
 

--- a/Tests/ImageResizer.Tests/TargetDimensionsTests.cs
+++ b/Tests/ImageResizer.Tests/TargetDimensionsTests.cs
@@ -1,0 +1,152 @@
+#region (c)2008-2026 Hawkynt
+/*
+ *  Image filtering library
+    Copyright (C) 2008-2026 Hawkynt
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using Classes;
+
+using NUnit.Framework;
+
+namespace ImageResizer.Tests {
+  /// <summary>
+  /// Covers the relative-size arithmetic the command line's <c>/resize &lt;p&gt;%</c> and the
+  /// window's percentage and scale-factor controls all share.
+  /// </summary>
+  [TestFixture]
+  public class TargetDimensionsTests {
+
+    #region scaling one dimension
+
+    [TestCase(100, 1.0, 100)]
+    [TestCase(100, 2.0, 200)]
+    [TestCase(100, 0.5, 50)]
+    [TestCase(16, 3.25, 52)]
+    public void ScalingMultipliesTheLength(int source, double factor, int expected)
+      => Assert.That(TargetDimensions.Scale(source, factor), Is.EqualTo(expected))
+    ;
+
+    /// <summary>
+    /// Regression: a small source scaled far down used to round to zero, and a zero-sized bitmap
+    /// cannot be allocated - the run ended in a runtime error instead of a very small image.
+    /// </summary>
+    [TestCase(16, 0.01)]
+    [TestCase(16, 0.02)]
+    [TestCase(1, 0.5)]
+    [TestCase(3, 0.1)]
+    public void ScalingNeverFallsBelowOnePixel(int source, double factor)
+      => Assert.That(TargetDimensions.Scale(source, factor), Is.EqualTo(TargetDimensions.MINIMUM))
+    ;
+
+    [TestCase(0)]
+    [TestCase(-5)]
+    public void ASourceWithoutSize_YieldsTheMinimum(int source)
+      => Assert.That(TargetDimensions.Scale(source, 2.0), Is.EqualTo(TargetDimensions.MINIMUM))
+    ;
+
+    [TestCase(0.0)]
+    [TestCase(-1.0)]
+    public void ANonPositiveFactor_YieldsTheMinimum(double factor)
+      => Assert.That(TargetDimensions.Scale(100, factor), Is.EqualTo(TargetDimensions.MINIMUM))
+    ;
+
+    [Test]
+    public void ScalingIsCappedAtTheMaximum()
+      => Assert.That(TargetDimensions.Scale(1000, 1000, 65535), Is.EqualTo(65535))
+    ;
+
+    [Test]
+    public void TheCapIsHonouredWhenTheCallerLowersIt()
+      => Assert.That(TargetDimensions.Scale(100, 10, 500), Is.EqualTo(500))
+    ;
+
+    [Test]
+    public void ScalingRoundsToTheNearestPixel() {
+      Assert.That(TargetDimensions.Scale(10, 1.14), Is.EqualTo(11));
+      Assert.That(TargetDimensions.Scale(10, 1.13), Is.EqualTo(11));
+      Assert.That(TargetDimensions.Scale(10, 1.11), Is.EqualTo(11));
+      Assert.That(TargetDimensions.Scale(10, 1.10), Is.EqualTo(11));
+    }
+
+    #endregion
+
+    #region percentages
+
+    [TestCase(100, 16, 16, 16, 16)]
+    [TestCase(200, 16, 16, 32, 32)]
+    [TestCase(325, 16, 16, 52, 52)]
+    [TestCase(50, 16, 24, 8, 12)]
+    public void APercentageScalesBothAxes(int percentage, int sourceWidth, int sourceHeight, int expectedWidth, int expectedHeight) {
+      TargetDimensions.FromPercentage(sourceWidth, sourceHeight, percentage, out var width, out var height);
+
+      Assert.That(width, Is.EqualTo(expectedWidth));
+      Assert.That(height, Is.EqualTo(expectedHeight));
+    }
+
+    [Test]
+    public void ATinyPercentageStillProducesAnImage() {
+      TargetDimensions.FromPercentage(16, 16, 1, out var width, out var height);
+
+      Assert.That(width, Is.EqualTo(1));
+      Assert.That(height, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void APercentageRespectsTheCap() {
+      TargetDimensions.FromPercentage(1000, 1000, 100000, out var width, out var height, 65535);
+
+      Assert.That(width, Is.EqualTo(65535));
+      Assert.That(height, Is.EqualTo(65535));
+    }
+
+    [Test]
+    public void ANonSquareSourceKeepsItsRatioUnderAPercentage() {
+      TargetDimensions.FromPercentage(400, 100, 50, out var width, out var height);
+
+      Assert.That(width, Is.EqualTo(200));
+      Assert.That(height, Is.EqualTo(50));
+    }
+
+    #endregion
+
+    #region reading a percentage back
+
+    [TestCase(100, 200, 200)]
+    [TestCase(100, 100, 100)]
+    [TestCase(100, 50, 50)]
+    [TestCase(16, 52, 325)]
+    public void ATargetIsExpressedAsAPercentageOfTheSource(int source, int target, double expected)
+      => Assert.That(TargetDimensions.ToPercentage(source, target), Is.EqualTo(expected).Within(0.001))
+    ;
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void ASourceWithoutSize_ReadsBackAsUnchanged(int source)
+      => Assert.That(TargetDimensions.ToPercentage(source, 50), Is.EqualTo(100))
+    ;
+
+    [Test]
+    public void ScalingAndReadingBack_AgreeWithEachOther() {
+      TargetDimensions.FromPercentage(160, 160, 325, out var width, out _);
+
+      Assert.That(TargetDimensions.ToPercentage(160, width), Is.EqualTo(325).Within(0.5));
+    }
+
+    #endregion
+
+  }
+}


### PR DESCRIPTION
The target resolution group gains a percentage mode, and a percentage that rounds a dimension down to zero is clamped instead of throwing.

Supersedes #42, which was opened before the branch was rebased off the stack it sat on.