### PR TITLE
# the smoke tier builds on the runner the gate builds on

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,5 +15,8 @@ jobs:
     uses: Hawkynt/RepositoryTemplate/.github/workflows/dotnet-smoke.yml@v1
     with:
       solution: ImageResizer.slnx
+      # The same runner ci.yml builds on. This is a WinForms solution with a Paint.NET plugin;
+      # the fast tier has to build what the gate builds, not a subset that happens to compile.
+      runs-on: windows-latest
       dotnet-version: '10.x'
       siblings: '[{"repository":"Hawkynt/C--FrameworkExtensions","path":".sibling/C--FrameworkExtensions"}]'

--- a/PixelArtScalingPlugin/PixelArtScaling.csproj
+++ b/PixelArtScalingPlugin/PixelArtScaling.csproj
@@ -27,9 +27,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>rem copy "$(TargetPath)" "D:\_copyapps\paint.net\effects\"</PostBuildEvent>
-  </PropertyGroup>
   <Import Project="..\VersionSpecificSymbols.Common.prop" />
   <ItemGroup>
     <Reference Include="PaintDotNet.Base">


### PR DESCRIPTION
The smoke tier I added in #53 took the shared workflow's default of `ubuntu-latest`. `ci.yml` builds this solution on **`windows-latest`**, and for good reason — it is a WinForms solution with a Paint.NET plugin. The fast tier has to build what the gate builds, not a subset that happens to compile.

That is my mistake and this fixes it. The smoke run on `main` is currently red because of it.

## The Linux attempt did find something real

`PixelArtScalingPlugin/PixelArtScaling.csproj` carried:

```xml
<PostBuildEvent>rem copy "$(TargetPath)" "D:\_copyapps\paint.net\effects\"</PostBuildEvent>
```

A developer's local copy step to a Paint.NET effects folder, commented out with `rem`. On Windows `rem` makes it a no-op, so it has done nothing for as long as it has been there. Under `sh` it is an *unterminated quoted string*, and the build dies:

```
/tmp/.../exec.cmd: Syntax error: Unterminated quoted string
error MSB3073: The command "rem copy "" "D:\_copyapps\paint.net\effects\"" exited with code 2.
```

Dead on every platform that can run it, fatal on every platform that cannot, and carrying a hard-coded `D:\` path from somebody's machine into the repository. Removed.

For the record, the tier is doing its job elsewhere — measured on their own branches: NativeForms 2.0 min, PhotoManager 1.4, ProcessManager 1.6, PB-Compiler 4.9, PNGCrushCS 5.2, against a pull-request gate of 25–40 minutes.